### PR TITLE
feat: add a button which lets the user generate advice on demand, instead of on page load

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,9 +8,11 @@
       "name": "frontend",
       "version": "0.1.0",
       "dependencies": {
+        "@nextui-org/button": "^2.0.37",
         "@nextui-org/popover": "^2.1.20",
         "@nextui-org/react": "^2.2.9",
         "@nextui-org/spinner": "^2.0.33",
+        "@nextui-org/system": "^2.2.5",
         "@nextui-org/tooltip": "^2.0.33",
         "@react-spring/parallax": "^9.7.3",
         "@testing-library/jest-dom": "^5.17.0",
@@ -2435,9 +2437,10 @@
       }
     },
     "node_modules/@formatjs/ecma402-abstract": {
-      "version": "1.18.2",
-      "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-1.18.2.tgz",
-      "integrity": "sha512-+QoPW4csYALsQIl8GbN14igZzDbuwzcpWrku9nyMXlaqAlwRBgl5V+p0vWMGFqHOw37czNXaP/lEk4wbLgcmtA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-2.0.0.tgz",
+      "integrity": "sha512-rRqXOqdFmk7RYvj4khklyqzcfQl9vEL/usogncBHRZfZBDOwMGuSRNFl02fu5KGHXdbinju+YXyuR+Nk8xlr/g==",
+      "license": "MIT",
       "dependencies": {
         "@formatjs/intl-localematcher": "0.5.4",
         "tslib": "^2.4.0"
@@ -2447,26 +2450,29 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@formatjs/fast-memoize/-/fast-memoize-2.2.0.tgz",
       "integrity": "sha512-hnk/nY8FyrL5YxwP9e4r9dqeM6cAbo8PeU9UjyXojZMNvVad2Z06FAVHyR3Ecw6fza+0GH7vdJgiKIVXTMbSBA==",
+      "license": "MIT",
       "dependencies": {
         "tslib": "^2.4.0"
       }
     },
     "node_modules/@formatjs/icu-messageformat-parser": {
-      "version": "2.7.6",
-      "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-2.7.6.tgz",
-      "integrity": "sha512-etVau26po9+eewJKYoiBKP6743I1br0/Ie00Pb/S/PtmYfmjTcOn2YCh2yNkSZI12h6Rg+BOgQYborXk46BvkA==",
+      "version": "2.7.8",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-2.7.8.tgz",
+      "integrity": "sha512-nBZJYmhpcSX0WeJ5SDYUkZ42AgR3xiyhNCsQweFx3cz/ULJjym8bHAzWKvG5e2+1XO98dBYC0fWeeAECAVSwLA==",
+      "license": "MIT",
       "dependencies": {
-        "@formatjs/ecma402-abstract": "1.18.2",
-        "@formatjs/icu-skeleton-parser": "1.8.0",
+        "@formatjs/ecma402-abstract": "2.0.0",
+        "@formatjs/icu-skeleton-parser": "1.8.2",
         "tslib": "^2.4.0"
       }
     },
     "node_modules/@formatjs/icu-skeleton-parser": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-1.8.0.tgz",
-      "integrity": "sha512-QWLAYvM0n8hv7Nq5BEs4LKIjevpVpbGLAJgOaYzg9wABEoX1j0JO1q2/jVkO6CVlq0dbsxZCngS5aXbysYueqA==",
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-1.8.2.tgz",
+      "integrity": "sha512-k4ERKgw7aKGWJZgTarIcNEmvyTVD9FYh0mTrrBMHZ1b8hUu6iOJ4SzsZlo3UNAvHYa+PnvntIwRPt1/vy4nA9Q==",
+      "license": "MIT",
       "dependencies": {
-        "@formatjs/ecma402-abstract": "1.18.2",
+        "@formatjs/ecma402-abstract": "2.0.0",
         "tslib": "^2.4.0"
       }
     },
@@ -2474,6 +2480,7 @@
       "version": "0.5.4",
       "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.5.4.tgz",
       "integrity": "sha512-zTwEpWOzZ2CiKcB93BLngUX59hQkuZjT2+SAQEscSm52peDW/getsawMcWF1rGRpMCX6D7nSJA3CzJ8gn13N/g==",
+      "license": "MIT",
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -2509,34 +2516,38 @@
       "integrity": "sha512-dvuCeX5fC9dXgJn9t+X5atfmgQAzUOWqS1254Gh0m6i8wKd10ebXkfNKiRK+1GWi/yTvvLDHpoxLr0xxxeslWw=="
     },
     "node_modules/@internationalized/date": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/@internationalized/date/-/date-3.5.2.tgz",
-      "integrity": "sha512-vo1yOMUt2hzp63IutEaTUxROdvQg1qlMRsbCvbay2AK2Gai7wIgCyK5weEX3nHkiLgo4qCXHijFNC/ILhlRpOQ==",
+      "version": "3.5.5",
+      "resolved": "https://registry.npmjs.org/@internationalized/date/-/date-3.5.5.tgz",
+      "integrity": "sha512-H+CfYvOZ0LTJeeLOqm19E3uj/4YjrmOFtBufDHPfvtI80hFAMqtrp7oCACpe4Cil5l8S0Qu/9dYfZc/5lY8WQQ==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@swc/helpers": "^0.5.0"
       }
     },
     "node_modules/@internationalized/message": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@internationalized/message/-/message-3.1.2.tgz",
-      "integrity": "sha512-MHAWsZWz8jf6jFPZqpTudcCM361YMtPIRu9CXkYmKjJ/0R3pQRScV5C0zS+Qi50O5UAm8ecKhkXx6mWDDcF6/g==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@internationalized/message/-/message-3.1.4.tgz",
+      "integrity": "sha512-Dygi9hH1s7V9nha07pggCkvmRfDd3q2lWnMGvrJyrOwYMe1yj4D2T9BoH9I6MGR7xz0biQrtLPsqUkqXzIrBOw==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@swc/helpers": "^0.5.0",
         "intl-messageformat": "^10.1.0"
       }
     },
     "node_modules/@internationalized/number": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/@internationalized/number/-/number-3.5.1.tgz",
-      "integrity": "sha512-N0fPU/nz15SwR9IbfJ5xaS9Ss/O5h1sVXMZf43vc9mxEG48ovglvvzBjF53aHlq20uoR6c+88CrIXipU/LSzwg==",
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/@internationalized/number/-/number-3.5.3.tgz",
+      "integrity": "sha512-rd1wA3ebzlp0Mehj5YTuTI50AQEx80gWFyHcQu+u91/5NgdwBecO8BH6ipPfE+lmQ9d63vpB3H9SHoIUiupllw==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@swc/helpers": "^0.5.0"
       }
     },
     "node_modules/@internationalized/string": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/@internationalized/string/-/string-3.2.1.tgz",
-      "integrity": "sha512-vWQOvRIauvFMzOO+h7QrdsJmtN1AXAFVcaLWP9AseRN2o7iHceZ6bIXhBD4teZl8i91A3gxKnWBlGgjCwU6MFQ==",
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/@internationalized/string/-/string-3.2.3.tgz",
+      "integrity": "sha512-9kpfLoA8HegiWTeCbR2livhdVeKobCnVv8tlJ6M2jF+4tcMqDo94ezwlnrUANBWPgd8U7OXIHCk2Ov2qhk4KXw==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@swc/helpers": "^0.5.0"
       }
@@ -3726,6 +3737,23 @@
         "react-dom": ">=18"
       }
     },
+    "node_modules/@nextui-org/aria-utils/node_modules/@nextui-org/system": {
+      "version": "2.0.15",
+      "resolved": "https://registry.npmjs.org/@nextui-org/system/-/system-2.0.15.tgz",
+      "integrity": "sha512-WFDq+Rx6D+gmK1YGEG2RBARPK9EOYonQDt5Tq2tUchzOOqj3kXXcM5Z0F3fudM59eIncLa/tX/ApJSTLry+hsw==",
+      "license": "MIT",
+      "dependencies": {
+        "@nextui-org/system-rsc": "2.0.11",
+        "@react-aria/i18n": "^3.8.4",
+        "@react-aria/overlays": "^3.18.1",
+        "@react-aria/utils": "^3.21.1",
+        "@react-stately/utils": "^3.8.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
     "node_modules/@nextui-org/autocomplete": {
       "version": "2.0.9",
       "resolved": "https://registry.npmjs.org/@nextui-org/autocomplete/-/autocomplete-2.0.9.tgz",
@@ -3750,6 +3778,32 @@
         "@react-aria/visually-hidden": "^3.8.6",
         "@react-stately/combobox": "^3.7.1",
         "@react-types/combobox": "^3.8.1",
+        "@react-types/shared": "^3.21.0"
+      },
+      "peerDependencies": {
+        "@nextui-org/system": ">=2.0.0",
+        "@nextui-org/theme": ">=2.1.0",
+        "framer-motion": ">=4.0.0",
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
+    "node_modules/@nextui-org/autocomplete/node_modules/@nextui-org/button": {
+      "version": "2.0.26",
+      "resolved": "https://registry.npmjs.org/@nextui-org/button/-/button-2.0.26.tgz",
+      "integrity": "sha512-mDrSII1oneY4omwDdxUhl5oLa3AhoWCchwV/jt7egunnAFie32HbTqfFYGpLGiJw3JMMh3WDUthrI1islVTRKA==",
+      "license": "MIT",
+      "dependencies": {
+        "@nextui-org/react-utils": "2.0.10",
+        "@nextui-org/ripple": "2.0.24",
+        "@nextui-org/shared-utils": "2.0.4",
+        "@nextui-org/spinner": "2.0.24",
+        "@nextui-org/use-aria-button": "2.0.6",
+        "@react-aria/button": "^3.8.4",
+        "@react-aria/focus": "^3.14.3",
+        "@react-aria/interactions": "^3.19.1",
+        "@react-aria/utils": "^3.21.1",
+        "@react-types/button": "^3.9.0",
         "@react-types/shared": "^3.21.0"
       },
       "peerDependencies": {
@@ -3861,44 +3915,87 @@
       }
     },
     "node_modules/@nextui-org/button": {
-      "version": "2.0.26",
-      "resolved": "https://registry.npmjs.org/@nextui-org/button/-/button-2.0.26.tgz",
-      "integrity": "sha512-mDrSII1oneY4omwDdxUhl5oLa3AhoWCchwV/jt7egunnAFie32HbTqfFYGpLGiJw3JMMh3WDUthrI1islVTRKA==",
+      "version": "2.0.37",
+      "resolved": "https://registry.npmjs.org/@nextui-org/button/-/button-2.0.37.tgz",
+      "integrity": "sha512-dBtdO30qfu+K4YYLNmmpUy16Q82H1ucY8A4NjP4iEAJ1sPunoAYvba7h9xabrpUKW9IOyItOThSesxsfpaXYug==",
+      "license": "MIT",
       "dependencies": {
-        "@nextui-org/react-utils": "2.0.10",
-        "@nextui-org/ripple": "2.0.24",
-        "@nextui-org/shared-utils": "2.0.4",
-        "@nextui-org/spinner": "2.0.24",
-        "@nextui-org/use-aria-button": "2.0.6",
-        "@react-aria/button": "^3.8.4",
-        "@react-aria/focus": "^3.14.3",
-        "@react-aria/interactions": "^3.19.1",
-        "@react-aria/utils": "^3.21.1",
-        "@react-types/button": "^3.9.0",
-        "@react-types/shared": "^3.21.0"
+        "@nextui-org/react-utils": "2.0.16",
+        "@nextui-org/ripple": "2.0.32",
+        "@nextui-org/shared-utils": "2.0.7",
+        "@nextui-org/spinner": "2.0.33",
+        "@nextui-org/use-aria-button": "2.0.10",
+        "@react-aria/button": "3.9.5",
+        "@react-aria/focus": "3.17.1",
+        "@react-aria/interactions": "3.21.3",
+        "@react-aria/utils": "3.24.1",
+        "@react-types/button": "3.9.4",
+        "@react-types/shared": "3.23.1"
       },
       "peerDependencies": {
         "@nextui-org/system": ">=2.0.0",
         "@nextui-org/theme": ">=2.1.0",
-        "framer-motion": ">=4.0.0",
+        "framer-motion": ">=10.17.0",
         "react": ">=18",
         "react-dom": ">=18"
       }
     },
-    "node_modules/@nextui-org/button/node_modules/@nextui-org/spinner": {
-      "version": "2.0.24",
-      "resolved": "https://registry.npmjs.org/@nextui-org/spinner/-/spinner-2.0.24.tgz",
-      "integrity": "sha512-s/q2FmxGPNEqA0ifWfc7xgs5a5D9c3xKkxL3n7jDoRnWo0NPlRsa6QRJGiSL5dHNoUqspRf/lNw2V94Bxk86Pg==",
+    "node_modules/@nextui-org/button/node_modules/@nextui-org/react-rsc-utils": {
+      "version": "2.0.13",
+      "resolved": "https://registry.npmjs.org/@nextui-org/react-rsc-utils/-/react-rsc-utils-2.0.13.tgz",
+      "integrity": "sha512-QewsXtoQlMsR9stThdazKEImg9oyZkPLs7wsymhrzh6/HdQCl9bTdb6tJcROg4vg5LRYKGG11USSQO2nKlfCcQ==",
+      "license": "MIT"
+    },
+    "node_modules/@nextui-org/button/node_modules/@nextui-org/react-utils": {
+      "version": "2.0.16",
+      "resolved": "https://registry.npmjs.org/@nextui-org/react-utils/-/react-utils-2.0.16.tgz",
+      "integrity": "sha512-QdDoqzhx+4t9cDTVmtw5iOrfyLvpqyKsq8PARHUniCiQQDQd1ao7FCpzHgvU9poYcEdRk+Lsna66zbeMkFBB6w==",
       "license": "MIT",
       "dependencies": {
-        "@nextui-org/react-utils": "2.0.10",
-        "@nextui-org/shared-utils": "2.0.4",
-        "@nextui-org/system-rsc": "2.0.11"
+        "@nextui-org/react-rsc-utils": "2.0.13",
+        "@nextui-org/shared-utils": "2.0.7"
       },
       "peerDependencies": {
+        "react": ">=18"
+      }
+    },
+    "node_modules/@nextui-org/button/node_modules/@nextui-org/ripple": {
+      "version": "2.0.32",
+      "resolved": "https://registry.npmjs.org/@nextui-org/ripple/-/ripple-2.0.32.tgz",
+      "integrity": "sha512-xOqoHWzpvv5KRh7P8pXt3aZEmI1tyhiTNhrwjJaRME0d5xSA0gNzYhrjP5g0+Dxy4nKRDIZ1znJcd87KI07JFA==",
+      "license": "MIT",
+      "dependencies": {
+        "@nextui-org/react-utils": "2.0.16",
+        "@nextui-org/shared-utils": "2.0.7"
+      },
+      "peerDependencies": {
+        "@nextui-org/system": ">=2.0.0",
         "@nextui-org/theme": ">=2.1.0",
+        "framer-motion": ">=10.17.0",
         "react": ">=18",
         "react-dom": ">=18"
+      }
+    },
+    "node_modules/@nextui-org/button/node_modules/@nextui-org/shared-utils": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@nextui-org/shared-utils/-/shared-utils-2.0.7.tgz",
+      "integrity": "sha512-FxY3N0i1Al7Oz3yOQN0dSpG8UUrLIP3iYh3ubD7BhdQoZLl5xbG6++q1gqOzZXV+ZWeUFMY/or0ofzWxGHiOow==",
+      "license": "MIT"
+    },
+    "node_modules/@nextui-org/button/node_modules/@nextui-org/use-aria-button": {
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/@nextui-org/use-aria-button/-/use-aria-button-2.0.10.tgz",
+      "integrity": "sha512-tUpp4QMr1zugKPevyToeRHIufTuc/g+67/r/oQLRTG0mMo3yGVmggykQuYn22fqqZPpW6nHcB9VYc+XtZZ27TQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-aria/focus": "3.17.1",
+        "@react-aria/interactions": "3.21.3",
+        "@react-aria/utils": "3.24.1",
+        "@react-types/button": "3.9.4",
+        "@react-types/shared": "3.23.1"
+      },
+      "peerDependencies": {
+        "react": ">=18"
       }
     },
     "node_modules/@nextui-org/card": {
@@ -4024,6 +4121,32 @@
         "react-dom": ">=18"
       }
     },
+    "node_modules/@nextui-org/dropdown/node_modules/@nextui-org/button": {
+      "version": "2.0.26",
+      "resolved": "https://registry.npmjs.org/@nextui-org/button/-/button-2.0.26.tgz",
+      "integrity": "sha512-mDrSII1oneY4omwDdxUhl5oLa3AhoWCchwV/jt7egunnAFie32HbTqfFYGpLGiJw3JMMh3WDUthrI1islVTRKA==",
+      "license": "MIT",
+      "dependencies": {
+        "@nextui-org/react-utils": "2.0.10",
+        "@nextui-org/ripple": "2.0.24",
+        "@nextui-org/shared-utils": "2.0.4",
+        "@nextui-org/spinner": "2.0.24",
+        "@nextui-org/use-aria-button": "2.0.6",
+        "@react-aria/button": "^3.8.4",
+        "@react-aria/focus": "^3.14.3",
+        "@react-aria/interactions": "^3.19.1",
+        "@react-aria/utils": "^3.21.1",
+        "@react-types/button": "^3.9.0",
+        "@react-types/shared": "^3.21.0"
+      },
+      "peerDependencies": {
+        "@nextui-org/system": ">=2.0.0",
+        "@nextui-org/theme": ">=2.1.0",
+        "framer-motion": ">=4.0.0",
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
     "node_modules/@nextui-org/dropdown/node_modules/@nextui-org/popover": {
       "version": "2.1.14",
       "resolved": "https://registry.npmjs.org/@nextui-org/popover/-/popover-2.1.14.tgz",
@@ -4053,6 +4176,22 @@
         "react-dom": ">=18"
       }
     },
+    "node_modules/@nextui-org/dropdown/node_modules/@nextui-org/spinner": {
+      "version": "2.0.24",
+      "resolved": "https://registry.npmjs.org/@nextui-org/spinner/-/spinner-2.0.24.tgz",
+      "integrity": "sha512-s/q2FmxGPNEqA0ifWfc7xgs5a5D9c3xKkxL3n7jDoRnWo0NPlRsa6QRJGiSL5dHNoUqspRf/lNw2V94Bxk86Pg==",
+      "license": "MIT",
+      "dependencies": {
+        "@nextui-org/react-utils": "2.0.10",
+        "@nextui-org/shared-utils": "2.0.4",
+        "@nextui-org/system-rsc": "2.0.11"
+      },
+      "peerDependencies": {
+        "@nextui-org/theme": ">=2.1.0",
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
     "node_modules/@nextui-org/framer-transitions": {
       "version": "2.0.15",
       "resolved": "https://registry.npmjs.org/@nextui-org/framer-transitions/-/framer-transitions-2.0.15.tgz",
@@ -4063,6 +4202,23 @@
       },
       "peerDependencies": {
         "framer-motion": ">=4.0.0",
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
+    "node_modules/@nextui-org/framer-transitions/node_modules/@nextui-org/system": {
+      "version": "2.0.15",
+      "resolved": "https://registry.npmjs.org/@nextui-org/system/-/system-2.0.15.tgz",
+      "integrity": "sha512-WFDq+Rx6D+gmK1YGEG2RBARPK9EOYonQDt5Tq2tUchzOOqj3kXXcM5Z0F3fudM59eIncLa/tX/ApJSTLry+hsw==",
+      "license": "MIT",
+      "dependencies": {
+        "@nextui-org/system-rsc": "2.0.11",
+        "@react-aria/i18n": "^3.8.4",
+        "@react-aria/overlays": "^3.18.1",
+        "@react-aria/utils": "^3.21.1",
+        "@react-stately/utils": "^3.8.0"
+      },
+      "peerDependencies": {
         "react": ">=18",
         "react-dom": ">=18"
       }
@@ -4635,6 +4791,32 @@
         "react": ">=18"
       }
     },
+    "node_modules/@nextui-org/react/node_modules/@nextui-org/button": {
+      "version": "2.0.26",
+      "resolved": "https://registry.npmjs.org/@nextui-org/button/-/button-2.0.26.tgz",
+      "integrity": "sha512-mDrSII1oneY4omwDdxUhl5oLa3AhoWCchwV/jt7egunnAFie32HbTqfFYGpLGiJw3JMMh3WDUthrI1islVTRKA==",
+      "license": "MIT",
+      "dependencies": {
+        "@nextui-org/react-utils": "2.0.10",
+        "@nextui-org/ripple": "2.0.24",
+        "@nextui-org/shared-utils": "2.0.4",
+        "@nextui-org/spinner": "2.0.24",
+        "@nextui-org/use-aria-button": "2.0.6",
+        "@react-aria/button": "^3.8.4",
+        "@react-aria/focus": "^3.14.3",
+        "@react-aria/interactions": "^3.19.1",
+        "@react-aria/utils": "^3.21.1",
+        "@react-types/button": "^3.9.0",
+        "@react-types/shared": "^3.21.0"
+      },
+      "peerDependencies": {
+        "@nextui-org/system": ">=2.0.0",
+        "@nextui-org/theme": ">=2.1.0",
+        "framer-motion": ">=4.0.0",
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
     "node_modules/@nextui-org/react/node_modules/@nextui-org/popover": {
       "version": "2.1.14",
       "resolved": "https://registry.npmjs.org/@nextui-org/popover/-/popover-2.1.14.tgz",
@@ -4676,6 +4858,23 @@
       },
       "peerDependencies": {
         "@nextui-org/theme": ">=2.1.0",
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
+    "node_modules/@nextui-org/react/node_modules/@nextui-org/system": {
+      "version": "2.0.15",
+      "resolved": "https://registry.npmjs.org/@nextui-org/system/-/system-2.0.15.tgz",
+      "integrity": "sha512-WFDq+Rx6D+gmK1YGEG2RBARPK9EOYonQDt5Tq2tUchzOOqj3kXXcM5Z0F3fudM59eIncLa/tX/ApJSTLry+hsw==",
+      "license": "MIT",
+      "dependencies": {
+        "@nextui-org/system-rsc": "2.0.11",
+        "@react-aria/i18n": "^3.8.4",
+        "@react-aria/overlays": "^3.18.1",
+        "@react-aria/utils": "^3.21.1",
+        "@react-stately/utils": "^3.8.0"
+      },
+      "peerDependencies": {
         "react": ">=18",
         "react-dom": ">=18"
       }
@@ -4756,6 +4955,32 @@
         "@react-aria/interactions": "^3.19.1",
         "@react-aria/utils": "^3.21.1",
         "@react-aria/visually-hidden": "^3.8.6",
+        "@react-types/shared": "^3.21.0"
+      },
+      "peerDependencies": {
+        "@nextui-org/system": ">=2.0.0",
+        "@nextui-org/theme": ">=2.1.0",
+        "framer-motion": ">=4.0.0",
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
+    "node_modules/@nextui-org/select/node_modules/@nextui-org/button": {
+      "version": "2.0.26",
+      "resolved": "https://registry.npmjs.org/@nextui-org/button/-/button-2.0.26.tgz",
+      "integrity": "sha512-mDrSII1oneY4omwDdxUhl5oLa3AhoWCchwV/jt7egunnAFie32HbTqfFYGpLGiJw3JMMh3WDUthrI1islVTRKA==",
+      "license": "MIT",
+      "dependencies": {
+        "@nextui-org/react-utils": "2.0.10",
+        "@nextui-org/ripple": "2.0.24",
+        "@nextui-org/shared-utils": "2.0.4",
+        "@nextui-org/spinner": "2.0.24",
+        "@nextui-org/use-aria-button": "2.0.6",
+        "@react-aria/button": "^3.8.4",
+        "@react-aria/focus": "^3.14.3",
+        "@react-aria/interactions": "^3.19.1",
+        "@react-aria/utils": "^3.21.1",
+        "@react-types/button": "^3.9.0",
         "@react-types/shared": "^3.21.0"
       },
       "peerDependencies": {
@@ -4913,6 +5138,48 @@
         "react-dom": ">=18"
       }
     },
+    "node_modules/@nextui-org/snippet/node_modules/@nextui-org/button": {
+      "version": "2.0.26",
+      "resolved": "https://registry.npmjs.org/@nextui-org/button/-/button-2.0.26.tgz",
+      "integrity": "sha512-mDrSII1oneY4omwDdxUhl5oLa3AhoWCchwV/jt7egunnAFie32HbTqfFYGpLGiJw3JMMh3WDUthrI1islVTRKA==",
+      "license": "MIT",
+      "dependencies": {
+        "@nextui-org/react-utils": "2.0.10",
+        "@nextui-org/ripple": "2.0.24",
+        "@nextui-org/shared-utils": "2.0.4",
+        "@nextui-org/spinner": "2.0.24",
+        "@nextui-org/use-aria-button": "2.0.6",
+        "@react-aria/button": "^3.8.4",
+        "@react-aria/focus": "^3.14.3",
+        "@react-aria/interactions": "^3.19.1",
+        "@react-aria/utils": "^3.21.1",
+        "@react-types/button": "^3.9.0",
+        "@react-types/shared": "^3.21.0"
+      },
+      "peerDependencies": {
+        "@nextui-org/system": ">=2.0.0",
+        "@nextui-org/theme": ">=2.1.0",
+        "framer-motion": ">=4.0.0",
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
+    "node_modules/@nextui-org/snippet/node_modules/@nextui-org/spinner": {
+      "version": "2.0.24",
+      "resolved": "https://registry.npmjs.org/@nextui-org/spinner/-/spinner-2.0.24.tgz",
+      "integrity": "sha512-s/q2FmxGPNEqA0ifWfc7xgs5a5D9c3xKkxL3n7jDoRnWo0NPlRsa6QRJGiSL5dHNoUqspRf/lNw2V94Bxk86Pg==",
+      "license": "MIT",
+      "dependencies": {
+        "@nextui-org/react-utils": "2.0.10",
+        "@nextui-org/shared-utils": "2.0.4",
+        "@nextui-org/system-rsc": "2.0.11"
+      },
+      "peerDependencies": {
+        "@nextui-org/theme": ">=2.1.0",
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
     "node_modules/@nextui-org/snippet/node_modules/@nextui-org/tooltip": {
       "version": "2.0.29",
       "resolved": "https://registry.npmjs.org/@nextui-org/tooltip/-/tooltip-2.0.29.tgz",
@@ -5032,17 +5299,21 @@
       }
     },
     "node_modules/@nextui-org/system": {
-      "version": "2.0.15",
-      "resolved": "https://registry.npmjs.org/@nextui-org/system/-/system-2.0.15.tgz",
-      "integrity": "sha512-WFDq+Rx6D+gmK1YGEG2RBARPK9EOYonQDt5Tq2tUchzOOqj3kXXcM5Z0F3fudM59eIncLa/tX/ApJSTLry+hsw==",
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/@nextui-org/system/-/system-2.2.5.tgz",
+      "integrity": "sha512-nrX6768aiyWtpxX3OTFBIVWR+v9nlMsC3KaBinNfek97sNm7gAfTHi7q5kylE3L5yIMpNG+DclAKpuxgDQEmvw==",
+      "license": "MIT",
       "dependencies": {
-        "@nextui-org/system-rsc": "2.0.11",
-        "@react-aria/i18n": "^3.8.4",
-        "@react-aria/overlays": "^3.18.1",
-        "@react-aria/utils": "^3.21.1",
-        "@react-stately/utils": "^3.8.0"
+        "@internationalized/date": "^3.5.4",
+        "@nextui-org/react-utils": "2.0.16",
+        "@nextui-org/system-rsc": "2.1.5",
+        "@react-aria/i18n": "3.11.1",
+        "@react-aria/overlays": "3.22.1",
+        "@react-aria/utils": "3.24.1",
+        "@react-stately/utils": "3.10.1"
       },
       "peerDependencies": {
+        "framer-motion": ">=10.17.0",
         "react": ">=18",
         "react-dom": ">=18"
       }
@@ -5058,6 +5329,57 @@
         "@nextui-org/theme": ">=2.1.0",
         "react": ">=18",
         "tailwind-variants": ">=0.1.13"
+      }
+    },
+    "node_modules/@nextui-org/system/node_modules/@nextui-org/react-rsc-utils": {
+      "version": "2.0.13",
+      "resolved": "https://registry.npmjs.org/@nextui-org/react-rsc-utils/-/react-rsc-utils-2.0.13.tgz",
+      "integrity": "sha512-QewsXtoQlMsR9stThdazKEImg9oyZkPLs7wsymhrzh6/HdQCl9bTdb6tJcROg4vg5LRYKGG11USSQO2nKlfCcQ==",
+      "license": "MIT"
+    },
+    "node_modules/@nextui-org/system/node_modules/@nextui-org/react-utils": {
+      "version": "2.0.16",
+      "resolved": "https://registry.npmjs.org/@nextui-org/react-utils/-/react-utils-2.0.16.tgz",
+      "integrity": "sha512-QdDoqzhx+4t9cDTVmtw5iOrfyLvpqyKsq8PARHUniCiQQDQd1ao7FCpzHgvU9poYcEdRk+Lsna66zbeMkFBB6w==",
+      "license": "MIT",
+      "dependencies": {
+        "@nextui-org/react-rsc-utils": "2.0.13",
+        "@nextui-org/shared-utils": "2.0.7"
+      },
+      "peerDependencies": {
+        "react": ">=18"
+      }
+    },
+    "node_modules/@nextui-org/system/node_modules/@nextui-org/shared-utils": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@nextui-org/shared-utils/-/shared-utils-2.0.7.tgz",
+      "integrity": "sha512-FxY3N0i1Al7Oz3yOQN0dSpG8UUrLIP3iYh3ubD7BhdQoZLl5xbG6++q1gqOzZXV+ZWeUFMY/or0ofzWxGHiOow==",
+      "license": "MIT"
+    },
+    "node_modules/@nextui-org/system/node_modules/@nextui-org/system-rsc": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nextui-org/system-rsc/-/system-rsc-2.1.5.tgz",
+      "integrity": "sha512-tkJLAyJu34Rr5KUMMqoB7cZjOVXB+7a/7N4ushZfuiLdoYijgmcXFMzLxjm+tbt9zA5AV+ivsfbHvscg77dJ6w==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-types/shared": "3.23.1",
+        "clsx": "^1.2.1"
+      },
+      "peerDependencies": {
+        "@nextui-org/theme": ">=2.1.0",
+        "react": ">=18"
+      }
+    },
+    "node_modules/@nextui-org/system/node_modules/@react-stately/utils": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/@react-stately/utils/-/utils-3.10.1.tgz",
+      "integrity": "sha512-VS/EHRyicef25zDZcM/ClpzYMC5i2YGN6uegOeQawmgfGjb02yaCX0F0zR69Pod9m2Hr3wunTbtpgVXvYbZItg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
       }
     },
     "node_modules/@nextui-org/table": {
@@ -5617,16 +5939,17 @@
       }
     },
     "node_modules/@react-aria/button": {
-      "version": "3.9.3",
-      "resolved": "https://registry.npmjs.org/@react-aria/button/-/button-3.9.3.tgz",
-      "integrity": "sha512-ZXo2VGTxfbaTEnfeIlm5ym4vYpGAy8sGrad8Scv+EyDAJWLMKokqctfaN6YSWbqUApC3FN63IvMqASflbmnYig==",
+      "version": "3.9.5",
+      "resolved": "https://registry.npmjs.org/@react-aria/button/-/button-3.9.5.tgz",
+      "integrity": "sha512-dgcYR6j8WDOMLKuVrtxzx4jIC05cVKDzc+HnPO8lNkBAOfjcuN5tkGRtIjLtqjMvpZHhQT5aDbgFpIaZzxgFIg==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@react-aria/focus": "^3.16.2",
-        "@react-aria/interactions": "^3.21.1",
-        "@react-aria/utils": "^3.23.2",
-        "@react-stately/toggle": "^3.7.2",
-        "@react-types/button": "^3.9.2",
-        "@react-types/shared": "^3.22.1",
+        "@react-aria/focus": "^3.17.1",
+        "@react-aria/interactions": "^3.21.3",
+        "@react-aria/utils": "^3.24.1",
+        "@react-stately/toggle": "^3.7.4",
+        "@react-types/button": "^3.9.4",
+        "@react-types/shared": "^3.23.1",
         "@swc/helpers": "^0.5.0"
       },
       "peerDependencies": {
@@ -5697,13 +6020,14 @@
       }
     },
     "node_modules/@react-aria/focus": {
-      "version": "3.16.2",
-      "resolved": "https://registry.npmjs.org/@react-aria/focus/-/focus-3.16.2.tgz",
-      "integrity": "sha512-Rqo9ummmgotESfypzFjI3uh58yMpL+E+lJBbQuXkBM0u0cU2YYzu0uOrFrq3zcHk997udZvq1pGK/R+2xk9B7g==",
+      "version": "3.17.1",
+      "resolved": "https://registry.npmjs.org/@react-aria/focus/-/focus-3.17.1.tgz",
+      "integrity": "sha512-FLTySoSNqX++u0nWZJPPN5etXY0WBxaIe/YuL/GTEeuqUIuC/2bJSaw5hlsM6T2yjy6Y/VAxBcKSdAFUlU6njQ==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@react-aria/interactions": "^3.21.1",
-        "@react-aria/utils": "^3.23.2",
-        "@react-types/shared": "^3.22.1",
+        "@react-aria/interactions": "^3.21.3",
+        "@react-aria/utils": "^3.24.1",
+        "@react-types/shared": "^3.23.1",
         "@swc/helpers": "^0.5.0",
         "clsx": "^2.0.0"
       },
@@ -5760,17 +6084,18 @@
       }
     },
     "node_modules/@react-aria/i18n": {
-      "version": "3.10.2",
-      "resolved": "https://registry.npmjs.org/@react-aria/i18n/-/i18n-3.10.2.tgz",
-      "integrity": "sha512-Z1ormoIvMOI4mEdcFLYsoJy9w/EzBdBmgfLP+S/Ah+1xwQOXpgwZxiKOhYHpWa0lf6hkKJL34N9MHJvCJ5Crvw==",
+      "version": "3.11.1",
+      "resolved": "https://registry.npmjs.org/@react-aria/i18n/-/i18n-3.11.1.tgz",
+      "integrity": "sha512-vuiBHw1kZruNMYeKkTGGnmPyMnM5T+gT8bz97H1FqIq1hQ6OPzmtBZ6W6l6OIMjeHI5oJo4utTwfZl495GALFQ==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@internationalized/date": "^3.5.2",
-        "@internationalized/message": "^3.1.2",
-        "@internationalized/number": "^3.5.1",
-        "@internationalized/string": "^3.2.1",
-        "@react-aria/ssr": "^3.9.2",
-        "@react-aria/utils": "^3.23.2",
-        "@react-types/shared": "^3.22.1",
+        "@internationalized/date": "^3.5.4",
+        "@internationalized/message": "^3.1.4",
+        "@internationalized/number": "^3.5.3",
+        "@internationalized/string": "^3.2.3",
+        "@react-aria/ssr": "^3.9.4",
+        "@react-aria/utils": "^3.24.1",
+        "@react-types/shared": "^3.23.1",
         "@swc/helpers": "^0.5.0"
       },
       "peerDependencies": {
@@ -5778,13 +6103,14 @@
       }
     },
     "node_modules/@react-aria/interactions": {
-      "version": "3.21.1",
-      "resolved": "https://registry.npmjs.org/@react-aria/interactions/-/interactions-3.21.1.tgz",
-      "integrity": "sha512-AlHf5SOzsShkHfV8GLLk3v9lEmYqYHURKcXWue0JdYbmquMRkUsf/+Tjl1+zHVAQ8lKqRnPYbTmc4AcZbqxltw==",
+      "version": "3.21.3",
+      "resolved": "https://registry.npmjs.org/@react-aria/interactions/-/interactions-3.21.3.tgz",
+      "integrity": "sha512-BWIuf4qCs5FreDJ9AguawLVS0lV9UU+sK4CCnbCNNmYqOWY+1+gRXCsnOM32K+oMESBxilAjdHW5n1hsMqYMpA==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@react-aria/ssr": "^3.9.2",
-        "@react-aria/utils": "^3.23.2",
-        "@react-types/shared": "^3.22.1",
+        "@react-aria/ssr": "^3.9.4",
+        "@react-aria/utils": "^3.24.1",
+        "@react-types/shared": "^3.23.1",
         "@swc/helpers": "^0.5.0"
       },
       "peerDependencies": {
@@ -5873,20 +6199,21 @@
       }
     },
     "node_modules/@react-aria/overlays": {
-      "version": "3.21.1",
-      "resolved": "https://registry.npmjs.org/@react-aria/overlays/-/overlays-3.21.1.tgz",
-      "integrity": "sha512-djEBDF+TbIIOHWWNpdm19+z8xtY8U+T+wKVQg/UZ6oWnclSqSWeGl70vu73Cg4HVBJ4hKf1SRx4Z/RN6VvH4Yw==",
+      "version": "3.22.1",
+      "resolved": "https://registry.npmjs.org/@react-aria/overlays/-/overlays-3.22.1.tgz",
+      "integrity": "sha512-GHiFMWO4EQ6+j6b5QCnNoOYiyx1Gk8ZiwLzzglCI4q1NY5AG2EAmfU4Z1+Gtrf2S5Y0zHbumC7rs9GnPoGLUYg==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@react-aria/focus": "^3.16.2",
-        "@react-aria/i18n": "^3.10.2",
-        "@react-aria/interactions": "^3.21.1",
-        "@react-aria/ssr": "^3.9.2",
-        "@react-aria/utils": "^3.23.2",
-        "@react-aria/visually-hidden": "^3.8.10",
-        "@react-stately/overlays": "^3.6.5",
-        "@react-types/button": "^3.9.2",
-        "@react-types/overlays": "^3.8.5",
-        "@react-types/shared": "^3.22.1",
+        "@react-aria/focus": "^3.17.1",
+        "@react-aria/i18n": "^3.11.1",
+        "@react-aria/interactions": "^3.21.3",
+        "@react-aria/ssr": "^3.9.4",
+        "@react-aria/utils": "^3.24.1",
+        "@react-aria/visually-hidden": "^3.8.12",
+        "@react-stately/overlays": "^3.6.7",
+        "@react-types/button": "^3.9.4",
+        "@react-types/overlays": "^3.8.7",
+        "@react-types/shared": "^3.23.1",
         "@swc/helpers": "^0.5.0"
       },
       "peerDependencies": {
@@ -5968,9 +6295,10 @@
       }
     },
     "node_modules/@react-aria/ssr": {
-      "version": "3.9.2",
-      "resolved": "https://registry.npmjs.org/@react-aria/ssr/-/ssr-3.9.2.tgz",
-      "integrity": "sha512-0gKkgDYdnq1w+ey8KzG9l+H5Z821qh9vVjztk55rUg71vTk/Eaebeir+WtzcLLwTjw3m/asIjx8Y59y1lJZhBw==",
+      "version": "3.9.5",
+      "resolved": "https://registry.npmjs.org/@react-aria/ssr/-/ssr-3.9.5.tgz",
+      "integrity": "sha512-xEwGKoysu+oXulibNUSkXf8itW0npHHTa6c4AyYeZIJyRoegeteYuFpZUBPtIDE8RfHdNsSmE1ssOkxRnwbkuQ==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@swc/helpers": "^0.5.0"
       },
@@ -5978,7 +6306,7 @@
         "node": ">= 12"
       },
       "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/@react-aria/switch": {
@@ -6094,13 +6422,14 @@
       }
     },
     "node_modules/@react-aria/utils": {
-      "version": "3.23.2",
-      "resolved": "https://registry.npmjs.org/@react-aria/utils/-/utils-3.23.2.tgz",
-      "integrity": "sha512-yznR9jJ0GG+YJvTMZxijQwVp+ahP66DY0apZf7X+dllyN+ByEDW+yaL1ewYPIpugxVzH5P8jhnBXsIyHKN411g==",
+      "version": "3.24.1",
+      "resolved": "https://registry.npmjs.org/@react-aria/utils/-/utils-3.24.1.tgz",
+      "integrity": "sha512-O3s9qhPMd6n42x9sKeJ3lhu5V1Tlnzhu6Yk8QOvDuXf7UGuUjXf9mzfHJt1dYzID4l9Fwm8toczBzPM9t0jc8Q==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@react-aria/ssr": "^3.9.2",
-        "@react-stately/utils": "^3.9.1",
-        "@react-types/shared": "^3.22.1",
+        "@react-aria/ssr": "^3.9.4",
+        "@react-stately/utils": "^3.10.1",
+        "@react-types/shared": "^3.23.1",
         "@swc/helpers": "^0.5.0",
         "clsx": "^2.0.0"
       },
@@ -6117,17 +6446,67 @@
       }
     },
     "node_modules/@react-aria/visually-hidden": {
-      "version": "3.8.10",
-      "resolved": "https://registry.npmjs.org/@react-aria/visually-hidden/-/visually-hidden-3.8.10.tgz",
-      "integrity": "sha512-np8c4wxdbE7ZrMv/bnjwEfpX0/nkWy9sELEb0sK8n4+HJ+WycoXXrVxBUb9tXgL/GCx5ReeDQChjQWwajm/z3A==",
+      "version": "3.8.14",
+      "resolved": "https://registry.npmjs.org/@react-aria/visually-hidden/-/visually-hidden-3.8.14.tgz",
+      "integrity": "sha512-DV3yagbAgO4ywQTq6D/AxcIaTC8c77r/SxlIMhQBMQ6vScJWTCh6zFG55wmLe3NKqvRrowv1OstlmYfZQ4v/XA==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@react-aria/interactions": "^3.21.1",
-        "@react-aria/utils": "^3.23.2",
-        "@react-types/shared": "^3.22.1",
+        "@react-aria/interactions": "^3.22.1",
+        "@react-aria/utils": "^3.25.1",
+        "@react-types/shared": "^3.24.1",
         "@swc/helpers": "^0.5.0"
       },
       "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@react-aria/visually-hidden/node_modules/@react-aria/interactions": {
+      "version": "3.22.1",
+      "resolved": "https://registry.npmjs.org/@react-aria/interactions/-/interactions-3.22.1.tgz",
+      "integrity": "sha512-5TLzQaDAQQ5C70yG8GInbO4wIylKY67RfTIIwQPGR/4n5OIjbUD8BOj3NuSsuZ/frUPaBXo1VEBBmSO23fxkjw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/ssr": "^3.9.5",
+        "@react-aria/utils": "^3.25.1",
+        "@react-types/shared": "^3.24.1",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@react-aria/visually-hidden/node_modules/@react-aria/utils": {
+      "version": "3.25.1",
+      "resolved": "https://registry.npmjs.org/@react-aria/utils/-/utils-3.25.1.tgz",
+      "integrity": "sha512-5Uj864e7T5+yj78ZfLnfHqmypLiqW2mN+nsdslog2z5ssunTqjolVeM15ootXskjISlZ7MojLpq97kIC4nlnAw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/ssr": "^3.9.5",
+        "@react-stately/utils": "^3.10.2",
+        "@react-types/shared": "^3.24.1",
+        "@swc/helpers": "^0.5.0",
+        "clsx": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@react-aria/visually-hidden/node_modules/@react-types/shared": {
+      "version": "3.24.1",
+      "resolved": "https://registry.npmjs.org/@react-types/shared/-/shared-3.24.1.tgz",
+      "integrity": "sha512-AUQeGYEm/zDTN6zLzdXolDxz3Jk5dDL7f506F07U8tBwxNNI3WRdhU84G0/AaFikOZzDXhOZDr3MhQMzyE7Ydw==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@react-aria/visually-hidden/node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/@react-spring/animated": {
@@ -6323,16 +6702,17 @@
       }
     },
     "node_modules/@react-stately/overlays": {
-      "version": "3.6.5",
-      "resolved": "https://registry.npmjs.org/@react-stately/overlays/-/overlays-3.6.5.tgz",
-      "integrity": "sha512-U4rCFj6TPJPXLUvYXAcvh+yP/CO2W+7f0IuqP7ZZGE+Osk9qFkT+zRK5/6ayhBDFpmueNfjIEAzT9gYPQwNHFw==",
+      "version": "3.6.9",
+      "resolved": "https://registry.npmjs.org/@react-stately/overlays/-/overlays-3.6.9.tgz",
+      "integrity": "sha512-4chfyzKw7P2UEainm0yzjUgYwG1ovBejN88eTrn+O62x5huuMCwe0cbMxmYh4y7IhRFSee3jIJd0SP0u/+i39w==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@react-stately/utils": "^3.9.1",
-        "@react-types/overlays": "^3.8.5",
+        "@react-stately/utils": "^3.10.2",
+        "@react-types/overlays": "^3.8.9",
         "@swc/helpers": "^0.5.0"
       },
       "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/@react-stately/radio": {
@@ -6428,16 +6808,17 @@
       }
     },
     "node_modules/@react-stately/toggle": {
-      "version": "3.7.2",
-      "resolved": "https://registry.npmjs.org/@react-stately/toggle/-/toggle-3.7.2.tgz",
-      "integrity": "sha512-SHCF2btcoK57c4lyhucRbyPBAFpp0Pdp0vcPdn3hUgqbu6e5gE0CwG/mgFmZRAQoc7PRc7XifL0uNw8diJJI0Q==",
+      "version": "3.7.6",
+      "resolved": "https://registry.npmjs.org/@react-stately/toggle/-/toggle-3.7.6.tgz",
+      "integrity": "sha512-xRZyrjNVu1VCd1xpg5RwmNYs9fXb+JHChoUaRcBmGCCjsPD0R5uR3iNuE17RXJtWS3/8o9IJVn90+/7NW7boOg==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@react-stately/utils": "^3.9.1",
-        "@react-types/checkbox": "^3.7.1",
+        "@react-stately/utils": "^3.10.2",
+        "@react-types/checkbox": "^3.8.3",
         "@swc/helpers": "^0.5.0"
       },
       "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/@react-stately/tooltip": {
@@ -6469,14 +6850,15 @@
       }
     },
     "node_modules/@react-stately/utils": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/@react-stately/utils/-/utils-3.9.1.tgz",
-      "integrity": "sha512-yzw75GE0iUWiyps02BOAPTrybcsMIxEJlzXqtvllAb01O9uX5n0i3X+u2eCpj2UoDF4zS08Ps0jPgWxg8xEYtA==",
+      "version": "3.10.2",
+      "resolved": "https://registry.npmjs.org/@react-stately/utils/-/utils-3.10.2.tgz",
+      "integrity": "sha512-fh6OTQtbeQC0ywp6LJuuKs6tKIgFvt/DlIZEcIpGho6/oZG229UnIk6TUekwxnDbumuYyan6D9EgUtEMmT8UIg==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@swc/helpers": "^0.5.0"
       },
       "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/@react-stately/virtualizer": {
@@ -6516,25 +6898,36 @@
       }
     },
     "node_modules/@react-types/button": {
-      "version": "3.9.2",
-      "resolved": "https://registry.npmjs.org/@react-types/button/-/button-3.9.2.tgz",
-      "integrity": "sha512-EnPTkGHZRtiwAoJy5q9lDjoG30bEzA/qnvKG29VVXKYAGeqY2IlFs1ypmU+z1X/CpJgPcG3I5cakM7yTVm3pSg==",
+      "version": "3.9.4",
+      "resolved": "https://registry.npmjs.org/@react-types/button/-/button-3.9.4.tgz",
+      "integrity": "sha512-raeQBJUxBp0axNF74TXB8/H50GY8Q3eV6cEKMbZFP1+Dzr09Ngv0tJBeW0ewAxAguNH5DRoMUAUGIXtSXskVdA==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@react-types/shared": "^3.22.1"
+        "@react-types/shared": "^3.23.1"
       },
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
       }
     },
     "node_modules/@react-types/checkbox": {
-      "version": "3.7.1",
-      "resolved": "https://registry.npmjs.org/@react-types/checkbox/-/checkbox-3.7.1.tgz",
-      "integrity": "sha512-kuGqjQFex0As/3gfWyk+e9njCcad/ZdnYLLiNvhlk15730xfa0MmnOdpqo9jfuFSXBjOcpxoofvEhvrRMtEdUA==",
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/@react-types/checkbox/-/checkbox-3.8.3.tgz",
+      "integrity": "sha512-f4c1mnLEt0iS1NMkyZXgT3q3AgcxzDk7w6MSONOKydcnh0xG5L2oefY14DhVDLkAuQS7jThlUFwiAs+MxiO3MA==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@react-types/shared": "^3.22.1"
+        "@react-types/shared": "^3.24.1"
       },
       "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@react-types/checkbox/node_modules/@react-types/shared": {
+      "version": "3.24.1",
+      "resolved": "https://registry.npmjs.org/@react-types/shared/-/shared-3.24.1.tgz",
+      "integrity": "sha512-AUQeGYEm/zDTN6zLzdXolDxz3Jk5dDL7f506F07U8tBwxNNI3WRdhU84G0/AaFikOZzDXhOZDr3MhQMzyE7Ydw==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/@react-types/combobox": {
@@ -6606,14 +6999,24 @@
       }
     },
     "node_modules/@react-types/overlays": {
-      "version": "3.8.5",
-      "resolved": "https://registry.npmjs.org/@react-types/overlays/-/overlays-3.8.5.tgz",
-      "integrity": "sha512-4D7EEBQigD/m8hE68Ys8eloyyZFHHduqykSIgINJ0edmo0jygRbWlTwuhWFR9USgSP4dK54duN0Mvq0m4HEVEw==",
+      "version": "3.8.9",
+      "resolved": "https://registry.npmjs.org/@react-types/overlays/-/overlays-3.8.9.tgz",
+      "integrity": "sha512-9ni9upQgXPnR+K9cWmbYWvm3ll9gH8P/XsEZprqIV5zNLMF334jADK48h4jafb1X9RFnj0WbHo6BqcSObzjTig==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@react-types/shared": "^3.22.1"
+        "@react-types/shared": "^3.24.1"
       },
       "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@react-types/overlays/node_modules/@react-types/shared": {
+      "version": "3.24.1",
+      "resolved": "https://registry.npmjs.org/@react-types/shared/-/shared-3.24.1.tgz",
+      "integrity": "sha512-AUQeGYEm/zDTN6zLzdXolDxz3Jk5dDL7f506F07U8tBwxNNI3WRdhU84G0/AaFikOZzDXhOZDr3MhQMzyE7Ydw==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/@react-types/progress": {
@@ -13066,9 +13469,10 @@
       }
     },
     "node_modules/framer-motion": {
-      "version": "10.16.16",
-      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-10.16.16.tgz",
-      "integrity": "sha512-je6j91rd7NmUX7L1XHouwJ4v3R+SO4umso2LUcgOct3rHZ0PajZ80ETYZTajzEXEl9DlKyzjyt4AvGQ+lrebOw==",
+      "version": "10.18.0",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-10.18.0.tgz",
+      "integrity": "sha512-oGlDh1Q1XqYPksuTD/usb0I70hq95OUzmL9+6Zd+Hs4XV0oaISBa/UUMSjYiq6m8EUF32132mOJ8xVZS+I0S6w==",
+      "license": "MIT",
       "dependencies": {
         "tslib": "^2.4.0"
       },
@@ -13861,13 +14265,14 @@
       }
     },
     "node_modules/intl-messageformat": {
-      "version": "10.5.11",
-      "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-10.5.11.tgz",
-      "integrity": "sha512-eYq5fkFBVxc7GIFDzpFQkDOZgNayNTQn4Oufe8jw6YY6OHVw70/4pA3FyCsQ0Gb2DnvEJEMmN2tOaXUGByM+kg==",
+      "version": "10.5.14",
+      "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-10.5.14.tgz",
+      "integrity": "sha512-IjC6sI0X7YRjjyVH9aUgdftcmZK7WXdHeil4KwbjDnRWjnVitKpAx3rr6t6di1joFp5188VqKcobOPA6mCLG/w==",
+      "license": "BSD-3-Clause",
       "dependencies": {
-        "@formatjs/ecma402-abstract": "1.18.2",
+        "@formatjs/ecma402-abstract": "2.0.0",
         "@formatjs/fast-memoize": "2.2.0",
-        "@formatjs/icu-messageformat-parser": "2.7.6",
+        "@formatjs/icu-messageformat-parser": "2.7.8",
         "tslib": "^2.4.0"
       }
     },
@@ -25597,9 +26002,9 @@
       "integrity": "sha512-qQfo2mxH5yVom1kacMtZZJFVdW+E70mqHMJvVg6WTLo+VBuQJ4TojZlfWBjK0ve5BdEeNAVxOsl/nvNMpJOaJA=="
     },
     "@formatjs/ecma402-abstract": {
-      "version": "1.18.2",
-      "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-1.18.2.tgz",
-      "integrity": "sha512-+QoPW4csYALsQIl8GbN14igZzDbuwzcpWrku9nyMXlaqAlwRBgl5V+p0vWMGFqHOw37czNXaP/lEk4wbLgcmtA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-2.0.0.tgz",
+      "integrity": "sha512-rRqXOqdFmk7RYvj4khklyqzcfQl9vEL/usogncBHRZfZBDOwMGuSRNFl02fu5KGHXdbinju+YXyuR+Nk8xlr/g==",
       "requires": {
         "@formatjs/intl-localematcher": "0.5.4",
         "tslib": "^2.4.0"
@@ -25614,21 +26019,21 @@
       }
     },
     "@formatjs/icu-messageformat-parser": {
-      "version": "2.7.6",
-      "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-2.7.6.tgz",
-      "integrity": "sha512-etVau26po9+eewJKYoiBKP6743I1br0/Ie00Pb/S/PtmYfmjTcOn2YCh2yNkSZI12h6Rg+BOgQYborXk46BvkA==",
+      "version": "2.7.8",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-2.7.8.tgz",
+      "integrity": "sha512-nBZJYmhpcSX0WeJ5SDYUkZ42AgR3xiyhNCsQweFx3cz/ULJjym8bHAzWKvG5e2+1XO98dBYC0fWeeAECAVSwLA==",
       "requires": {
-        "@formatjs/ecma402-abstract": "1.18.2",
-        "@formatjs/icu-skeleton-parser": "1.8.0",
+        "@formatjs/ecma402-abstract": "2.0.0",
+        "@formatjs/icu-skeleton-parser": "1.8.2",
         "tslib": "^2.4.0"
       }
     },
     "@formatjs/icu-skeleton-parser": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-1.8.0.tgz",
-      "integrity": "sha512-QWLAYvM0n8hv7Nq5BEs4LKIjevpVpbGLAJgOaYzg9wABEoX1j0JO1q2/jVkO6CVlq0dbsxZCngS5aXbysYueqA==",
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-1.8.2.tgz",
+      "integrity": "sha512-k4ERKgw7aKGWJZgTarIcNEmvyTVD9FYh0mTrrBMHZ1b8hUu6iOJ4SzsZlo3UNAvHYa+PnvntIwRPt1/vy4nA9Q==",
       "requires": {
-        "@formatjs/ecma402-abstract": "1.18.2",
+        "@formatjs/ecma402-abstract": "2.0.0",
         "tslib": "^2.4.0"
       }
     },
@@ -25661,34 +26066,34 @@
       "integrity": "sha512-dvuCeX5fC9dXgJn9t+X5atfmgQAzUOWqS1254Gh0m6i8wKd10ebXkfNKiRK+1GWi/yTvvLDHpoxLr0xxxeslWw=="
     },
     "@internationalized/date": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/@internationalized/date/-/date-3.5.2.tgz",
-      "integrity": "sha512-vo1yOMUt2hzp63IutEaTUxROdvQg1qlMRsbCvbay2AK2Gai7wIgCyK5weEX3nHkiLgo4qCXHijFNC/ILhlRpOQ==",
+      "version": "3.5.5",
+      "resolved": "https://registry.npmjs.org/@internationalized/date/-/date-3.5.5.tgz",
+      "integrity": "sha512-H+CfYvOZ0LTJeeLOqm19E3uj/4YjrmOFtBufDHPfvtI80hFAMqtrp7oCACpe4Cil5l8S0Qu/9dYfZc/5lY8WQQ==",
       "requires": {
         "@swc/helpers": "^0.5.0"
       }
     },
     "@internationalized/message": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@internationalized/message/-/message-3.1.2.tgz",
-      "integrity": "sha512-MHAWsZWz8jf6jFPZqpTudcCM361YMtPIRu9CXkYmKjJ/0R3pQRScV5C0zS+Qi50O5UAm8ecKhkXx6mWDDcF6/g==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@internationalized/message/-/message-3.1.4.tgz",
+      "integrity": "sha512-Dygi9hH1s7V9nha07pggCkvmRfDd3q2lWnMGvrJyrOwYMe1yj4D2T9BoH9I6MGR7xz0biQrtLPsqUkqXzIrBOw==",
       "requires": {
         "@swc/helpers": "^0.5.0",
         "intl-messageformat": "^10.1.0"
       }
     },
     "@internationalized/number": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/@internationalized/number/-/number-3.5.1.tgz",
-      "integrity": "sha512-N0fPU/nz15SwR9IbfJ5xaS9Ss/O5h1sVXMZf43vc9mxEG48ovglvvzBjF53aHlq20uoR6c+88CrIXipU/LSzwg==",
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/@internationalized/number/-/number-3.5.3.tgz",
+      "integrity": "sha512-rd1wA3ebzlp0Mehj5YTuTI50AQEx80gWFyHcQu+u91/5NgdwBecO8BH6ipPfE+lmQ9d63vpB3H9SHoIUiupllw==",
       "requires": {
         "@swc/helpers": "^0.5.0"
       }
     },
     "@internationalized/string": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/@internationalized/string/-/string-3.2.1.tgz",
-      "integrity": "sha512-vWQOvRIauvFMzOO+h7QrdsJmtN1AXAFVcaLWP9AseRN2o7iHceZ6bIXhBD4teZl8i91A3gxKnWBlGgjCwU6MFQ==",
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/@internationalized/string/-/string-3.2.3.tgz",
+      "integrity": "sha512-9kpfLoA8HegiWTeCbR2livhdVeKobCnVv8tlJ6M2jF+4tcMqDo94ezwlnrUANBWPgd8U7OXIHCk2Ov2qhk4KXw==",
       "requires": {
         "@swc/helpers": "^0.5.0"
       }
@@ -26596,6 +27001,20 @@
         "@react-stately/collections": "^3.10.2",
         "@react-types/overlays": "^3.8.3",
         "@react-types/shared": "^3.21.0"
+      },
+      "dependencies": {
+        "@nextui-org/system": {
+          "version": "2.0.15",
+          "resolved": "https://registry.npmjs.org/@nextui-org/system/-/system-2.0.15.tgz",
+          "integrity": "sha512-WFDq+Rx6D+gmK1YGEG2RBARPK9EOYonQDt5Tq2tUchzOOqj3kXXcM5Z0F3fudM59eIncLa/tX/ApJSTLry+hsw==",
+          "requires": {
+            "@nextui-org/system-rsc": "2.0.11",
+            "@react-aria/i18n": "^3.8.4",
+            "@react-aria/overlays": "^3.18.1",
+            "@react-aria/utils": "^3.21.1",
+            "@react-stately/utils": "^3.8.0"
+          }
+        }
       }
     },
     "@nextui-org/autocomplete": {
@@ -26625,6 +27044,24 @@
         "@react-types/shared": "^3.21.0"
       },
       "dependencies": {
+        "@nextui-org/button": {
+          "version": "2.0.26",
+          "resolved": "https://registry.npmjs.org/@nextui-org/button/-/button-2.0.26.tgz",
+          "integrity": "sha512-mDrSII1oneY4omwDdxUhl5oLa3AhoWCchwV/jt7egunnAFie32HbTqfFYGpLGiJw3JMMh3WDUthrI1islVTRKA==",
+          "requires": {
+            "@nextui-org/react-utils": "2.0.10",
+            "@nextui-org/ripple": "2.0.24",
+            "@nextui-org/shared-utils": "2.0.4",
+            "@nextui-org/spinner": "2.0.24",
+            "@nextui-org/use-aria-button": "2.0.6",
+            "@react-aria/button": "^3.8.4",
+            "@react-aria/focus": "^3.14.3",
+            "@react-aria/interactions": "^3.19.1",
+            "@react-aria/utils": "^3.21.1",
+            "@react-types/button": "^3.9.0",
+            "@react-types/shared": "^3.21.0"
+          }
+        },
         "@nextui-org/popover": {
           "version": "2.1.14",
           "resolved": "https://registry.npmjs.org/@nextui-org/popover/-/popover-2.1.14.tgz",
@@ -26698,31 +27135,61 @@
       }
     },
     "@nextui-org/button": {
-      "version": "2.0.26",
-      "resolved": "https://registry.npmjs.org/@nextui-org/button/-/button-2.0.26.tgz",
-      "integrity": "sha512-mDrSII1oneY4omwDdxUhl5oLa3AhoWCchwV/jt7egunnAFie32HbTqfFYGpLGiJw3JMMh3WDUthrI1islVTRKA==",
+      "version": "2.0.37",
+      "resolved": "https://registry.npmjs.org/@nextui-org/button/-/button-2.0.37.tgz",
+      "integrity": "sha512-dBtdO30qfu+K4YYLNmmpUy16Q82H1ucY8A4NjP4iEAJ1sPunoAYvba7h9xabrpUKW9IOyItOThSesxsfpaXYug==",
       "requires": {
-        "@nextui-org/react-utils": "2.0.10",
-        "@nextui-org/ripple": "2.0.24",
-        "@nextui-org/shared-utils": "2.0.4",
-        "@nextui-org/spinner": "2.0.24",
-        "@nextui-org/use-aria-button": "2.0.6",
-        "@react-aria/button": "^3.8.4",
-        "@react-aria/focus": "^3.14.3",
-        "@react-aria/interactions": "^3.19.1",
-        "@react-aria/utils": "^3.21.1",
-        "@react-types/button": "^3.9.0",
-        "@react-types/shared": "^3.21.0"
+        "@nextui-org/react-utils": "2.0.16",
+        "@nextui-org/ripple": "2.0.32",
+        "@nextui-org/shared-utils": "2.0.7",
+        "@nextui-org/spinner": "2.0.33",
+        "@nextui-org/use-aria-button": "2.0.10",
+        "@react-aria/button": "3.9.5",
+        "@react-aria/focus": "3.17.1",
+        "@react-aria/interactions": "3.21.3",
+        "@react-aria/utils": "3.24.1",
+        "@react-types/button": "3.9.4",
+        "@react-types/shared": "3.23.1"
       },
       "dependencies": {
-        "@nextui-org/spinner": {
-          "version": "2.0.24",
-          "resolved": "https://registry.npmjs.org/@nextui-org/spinner/-/spinner-2.0.24.tgz",
-          "integrity": "sha512-s/q2FmxGPNEqA0ifWfc7xgs5a5D9c3xKkxL3n7jDoRnWo0NPlRsa6QRJGiSL5dHNoUqspRf/lNw2V94Bxk86Pg==",
+        "@nextui-org/react-rsc-utils": {
+          "version": "2.0.13",
+          "resolved": "https://registry.npmjs.org/@nextui-org/react-rsc-utils/-/react-rsc-utils-2.0.13.tgz",
+          "integrity": "sha512-QewsXtoQlMsR9stThdazKEImg9oyZkPLs7wsymhrzh6/HdQCl9bTdb6tJcROg4vg5LRYKGG11USSQO2nKlfCcQ=="
+        },
+        "@nextui-org/react-utils": {
+          "version": "2.0.16",
+          "resolved": "https://registry.npmjs.org/@nextui-org/react-utils/-/react-utils-2.0.16.tgz",
+          "integrity": "sha512-QdDoqzhx+4t9cDTVmtw5iOrfyLvpqyKsq8PARHUniCiQQDQd1ao7FCpzHgvU9poYcEdRk+Lsna66zbeMkFBB6w==",
           "requires": {
-            "@nextui-org/react-utils": "2.0.10",
-            "@nextui-org/shared-utils": "2.0.4",
-            "@nextui-org/system-rsc": "2.0.11"
+            "@nextui-org/react-rsc-utils": "2.0.13",
+            "@nextui-org/shared-utils": "2.0.7"
+          }
+        },
+        "@nextui-org/ripple": {
+          "version": "2.0.32",
+          "resolved": "https://registry.npmjs.org/@nextui-org/ripple/-/ripple-2.0.32.tgz",
+          "integrity": "sha512-xOqoHWzpvv5KRh7P8pXt3aZEmI1tyhiTNhrwjJaRME0d5xSA0gNzYhrjP5g0+Dxy4nKRDIZ1znJcd87KI07JFA==",
+          "requires": {
+            "@nextui-org/react-utils": "2.0.16",
+            "@nextui-org/shared-utils": "2.0.7"
+          }
+        },
+        "@nextui-org/shared-utils": {
+          "version": "2.0.7",
+          "resolved": "https://registry.npmjs.org/@nextui-org/shared-utils/-/shared-utils-2.0.7.tgz",
+          "integrity": "sha512-FxY3N0i1Al7Oz3yOQN0dSpG8UUrLIP3iYh3ubD7BhdQoZLl5xbG6++q1gqOzZXV+ZWeUFMY/or0ofzWxGHiOow=="
+        },
+        "@nextui-org/use-aria-button": {
+          "version": "2.0.10",
+          "resolved": "https://registry.npmjs.org/@nextui-org/use-aria-button/-/use-aria-button-2.0.10.tgz",
+          "integrity": "sha512-tUpp4QMr1zugKPevyToeRHIufTuc/g+67/r/oQLRTG0mMo3yGVmggykQuYn22fqqZPpW6nHcB9VYc+XtZZ27TQ==",
+          "requires": {
+            "@react-aria/focus": "3.17.1",
+            "@react-aria/interactions": "3.21.3",
+            "@react-aria/utils": "3.24.1",
+            "@react-types/button": "3.9.4",
+            "@react-types/shared": "3.23.1"
           }
         }
       }
@@ -26814,6 +27281,24 @@
         "@react-types/menu": "^3.9.5"
       },
       "dependencies": {
+        "@nextui-org/button": {
+          "version": "2.0.26",
+          "resolved": "https://registry.npmjs.org/@nextui-org/button/-/button-2.0.26.tgz",
+          "integrity": "sha512-mDrSII1oneY4omwDdxUhl5oLa3AhoWCchwV/jt7egunnAFie32HbTqfFYGpLGiJw3JMMh3WDUthrI1islVTRKA==",
+          "requires": {
+            "@nextui-org/react-utils": "2.0.10",
+            "@nextui-org/ripple": "2.0.24",
+            "@nextui-org/shared-utils": "2.0.4",
+            "@nextui-org/spinner": "2.0.24",
+            "@nextui-org/use-aria-button": "2.0.6",
+            "@react-aria/button": "^3.8.4",
+            "@react-aria/focus": "^3.14.3",
+            "@react-aria/interactions": "^3.19.1",
+            "@react-aria/utils": "^3.21.1",
+            "@react-types/button": "^3.9.0",
+            "@react-types/shared": "^3.21.0"
+          }
+        },
         "@nextui-org/popover": {
           "version": "2.1.14",
           "resolved": "https://registry.npmjs.org/@nextui-org/popover/-/popover-2.1.14.tgz",
@@ -26835,6 +27320,16 @@
             "@react-types/overlays": "^3.8.3",
             "react-remove-scroll": "^2.5.6"
           }
+        },
+        "@nextui-org/spinner": {
+          "version": "2.0.24",
+          "resolved": "https://registry.npmjs.org/@nextui-org/spinner/-/spinner-2.0.24.tgz",
+          "integrity": "sha512-s/q2FmxGPNEqA0ifWfc7xgs5a5D9c3xKkxL3n7jDoRnWo0NPlRsa6QRJGiSL5dHNoUqspRf/lNw2V94Bxk86Pg==",
+          "requires": {
+            "@nextui-org/react-utils": "2.0.10",
+            "@nextui-org/shared-utils": "2.0.4",
+            "@nextui-org/system-rsc": "2.0.11"
+          }
         }
       }
     },
@@ -26845,6 +27340,20 @@
       "requires": {
         "@nextui-org/shared-utils": "2.0.4",
         "@nextui-org/system": "2.0.15"
+      },
+      "dependencies": {
+        "@nextui-org/system": {
+          "version": "2.0.15",
+          "resolved": "https://registry.npmjs.org/@nextui-org/system/-/system-2.0.15.tgz",
+          "integrity": "sha512-WFDq+Rx6D+gmK1YGEG2RBARPK9EOYonQDt5Tq2tUchzOOqj3kXXcM5Z0F3fudM59eIncLa/tX/ApJSTLry+hsw==",
+          "requires": {
+            "@nextui-org/system-rsc": "2.0.11",
+            "@react-aria/i18n": "^3.8.4",
+            "@react-aria/overlays": "^3.18.1",
+            "@react-aria/utils": "^3.21.1",
+            "@react-stately/utils": "^3.8.0"
+          }
+        }
       }
     },
     "@nextui-org/framer-utils": {
@@ -27268,6 +27777,24 @@
         "@react-aria/visually-hidden": "^3.8.6"
       },
       "dependencies": {
+        "@nextui-org/button": {
+          "version": "2.0.26",
+          "resolved": "https://registry.npmjs.org/@nextui-org/button/-/button-2.0.26.tgz",
+          "integrity": "sha512-mDrSII1oneY4omwDdxUhl5oLa3AhoWCchwV/jt7egunnAFie32HbTqfFYGpLGiJw3JMMh3WDUthrI1islVTRKA==",
+          "requires": {
+            "@nextui-org/react-utils": "2.0.10",
+            "@nextui-org/ripple": "2.0.24",
+            "@nextui-org/shared-utils": "2.0.4",
+            "@nextui-org/spinner": "2.0.24",
+            "@nextui-org/use-aria-button": "2.0.6",
+            "@react-aria/button": "^3.8.4",
+            "@react-aria/focus": "^3.14.3",
+            "@react-aria/interactions": "^3.19.1",
+            "@react-aria/utils": "^3.21.1",
+            "@react-types/button": "^3.9.0",
+            "@react-types/shared": "^3.21.0"
+          }
+        },
         "@nextui-org/popover": {
           "version": "2.1.14",
           "resolved": "https://registry.npmjs.org/@nextui-org/popover/-/popover-2.1.14.tgz",
@@ -27298,6 +27825,18 @@
             "@nextui-org/react-utils": "2.0.10",
             "@nextui-org/shared-utils": "2.0.4",
             "@nextui-org/system-rsc": "2.0.11"
+          }
+        },
+        "@nextui-org/system": {
+          "version": "2.0.15",
+          "resolved": "https://registry.npmjs.org/@nextui-org/system/-/system-2.0.15.tgz",
+          "integrity": "sha512-WFDq+Rx6D+gmK1YGEG2RBARPK9EOYonQDt5Tq2tUchzOOqj3kXXcM5Z0F3fudM59eIncLa/tX/ApJSTLry+hsw==",
+          "requires": {
+            "@nextui-org/system-rsc": "2.0.11",
+            "@react-aria/i18n": "^3.8.4",
+            "@react-aria/overlays": "^3.18.1",
+            "@react-aria/utils": "^3.21.1",
+            "@react-stately/utils": "^3.8.0"
           }
         },
         "@nextui-org/tooltip": {
@@ -27375,6 +27914,24 @@
         "@react-types/shared": "^3.21.0"
       },
       "dependencies": {
+        "@nextui-org/button": {
+          "version": "2.0.26",
+          "resolved": "https://registry.npmjs.org/@nextui-org/button/-/button-2.0.26.tgz",
+          "integrity": "sha512-mDrSII1oneY4omwDdxUhl5oLa3AhoWCchwV/jt7egunnAFie32HbTqfFYGpLGiJw3JMMh3WDUthrI1islVTRKA==",
+          "requires": {
+            "@nextui-org/react-utils": "2.0.10",
+            "@nextui-org/ripple": "2.0.24",
+            "@nextui-org/shared-utils": "2.0.4",
+            "@nextui-org/spinner": "2.0.24",
+            "@nextui-org/use-aria-button": "2.0.6",
+            "@react-aria/button": "^3.8.4",
+            "@react-aria/focus": "^3.14.3",
+            "@react-aria/interactions": "^3.19.1",
+            "@react-aria/utils": "^3.21.1",
+            "@react-types/button": "^3.9.0",
+            "@react-types/shared": "^3.21.0"
+          }
+        },
         "@nextui-org/popover": {
           "version": "2.1.14",
           "resolved": "https://registry.npmjs.org/@nextui-org/popover/-/popover-2.1.14.tgz",
@@ -27484,6 +28041,34 @@
         "@react-aria/utils": "^3.21.1"
       },
       "dependencies": {
+        "@nextui-org/button": {
+          "version": "2.0.26",
+          "resolved": "https://registry.npmjs.org/@nextui-org/button/-/button-2.0.26.tgz",
+          "integrity": "sha512-mDrSII1oneY4omwDdxUhl5oLa3AhoWCchwV/jt7egunnAFie32HbTqfFYGpLGiJw3JMMh3WDUthrI1islVTRKA==",
+          "requires": {
+            "@nextui-org/react-utils": "2.0.10",
+            "@nextui-org/ripple": "2.0.24",
+            "@nextui-org/shared-utils": "2.0.4",
+            "@nextui-org/spinner": "2.0.24",
+            "@nextui-org/use-aria-button": "2.0.6",
+            "@react-aria/button": "^3.8.4",
+            "@react-aria/focus": "^3.14.3",
+            "@react-aria/interactions": "^3.19.1",
+            "@react-aria/utils": "^3.21.1",
+            "@react-types/button": "^3.9.0",
+            "@react-types/shared": "^3.21.0"
+          }
+        },
+        "@nextui-org/spinner": {
+          "version": "2.0.24",
+          "resolved": "https://registry.npmjs.org/@nextui-org/spinner/-/spinner-2.0.24.tgz",
+          "integrity": "sha512-s/q2FmxGPNEqA0ifWfc7xgs5a5D9c3xKkxL3n7jDoRnWo0NPlRsa6QRJGiSL5dHNoUqspRf/lNw2V94Bxk86Pg==",
+          "requires": {
+            "@nextui-org/react-utils": "2.0.10",
+            "@nextui-org/shared-utils": "2.0.4",
+            "@nextui-org/system-rsc": "2.0.11"
+          }
+        },
         "@nextui-org/tooltip": {
           "version": "2.0.29",
           "resolved": "https://registry.npmjs.org/@nextui-org/tooltip/-/tooltip-2.0.29.tgz",
@@ -27572,15 +28157,55 @@
       }
     },
     "@nextui-org/system": {
-      "version": "2.0.15",
-      "resolved": "https://registry.npmjs.org/@nextui-org/system/-/system-2.0.15.tgz",
-      "integrity": "sha512-WFDq+Rx6D+gmK1YGEG2RBARPK9EOYonQDt5Tq2tUchzOOqj3kXXcM5Z0F3fudM59eIncLa/tX/ApJSTLry+hsw==",
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/@nextui-org/system/-/system-2.2.5.tgz",
+      "integrity": "sha512-nrX6768aiyWtpxX3OTFBIVWR+v9nlMsC3KaBinNfek97sNm7gAfTHi7q5kylE3L5yIMpNG+DclAKpuxgDQEmvw==",
       "requires": {
-        "@nextui-org/system-rsc": "2.0.11",
-        "@react-aria/i18n": "^3.8.4",
-        "@react-aria/overlays": "^3.18.1",
-        "@react-aria/utils": "^3.21.1",
-        "@react-stately/utils": "^3.8.0"
+        "@internationalized/date": "^3.5.4",
+        "@nextui-org/react-utils": "2.0.16",
+        "@nextui-org/system-rsc": "2.1.5",
+        "@react-aria/i18n": "3.11.1",
+        "@react-aria/overlays": "3.22.1",
+        "@react-aria/utils": "3.24.1",
+        "@react-stately/utils": "3.10.1"
+      },
+      "dependencies": {
+        "@nextui-org/react-rsc-utils": {
+          "version": "2.0.13",
+          "resolved": "https://registry.npmjs.org/@nextui-org/react-rsc-utils/-/react-rsc-utils-2.0.13.tgz",
+          "integrity": "sha512-QewsXtoQlMsR9stThdazKEImg9oyZkPLs7wsymhrzh6/HdQCl9bTdb6tJcROg4vg5LRYKGG11USSQO2nKlfCcQ=="
+        },
+        "@nextui-org/react-utils": {
+          "version": "2.0.16",
+          "resolved": "https://registry.npmjs.org/@nextui-org/react-utils/-/react-utils-2.0.16.tgz",
+          "integrity": "sha512-QdDoqzhx+4t9cDTVmtw5iOrfyLvpqyKsq8PARHUniCiQQDQd1ao7FCpzHgvU9poYcEdRk+Lsna66zbeMkFBB6w==",
+          "requires": {
+            "@nextui-org/react-rsc-utils": "2.0.13",
+            "@nextui-org/shared-utils": "2.0.7"
+          }
+        },
+        "@nextui-org/shared-utils": {
+          "version": "2.0.7",
+          "resolved": "https://registry.npmjs.org/@nextui-org/shared-utils/-/shared-utils-2.0.7.tgz",
+          "integrity": "sha512-FxY3N0i1Al7Oz3yOQN0dSpG8UUrLIP3iYh3ubD7BhdQoZLl5xbG6++q1gqOzZXV+ZWeUFMY/or0ofzWxGHiOow=="
+        },
+        "@nextui-org/system-rsc": {
+          "version": "2.1.5",
+          "resolved": "https://registry.npmjs.org/@nextui-org/system-rsc/-/system-rsc-2.1.5.tgz",
+          "integrity": "sha512-tkJLAyJu34Rr5KUMMqoB7cZjOVXB+7a/7N4ushZfuiLdoYijgmcXFMzLxjm+tbt9zA5AV+ivsfbHvscg77dJ6w==",
+          "requires": {
+            "@react-types/shared": "3.23.1",
+            "clsx": "^1.2.1"
+          }
+        },
+        "@react-stately/utils": {
+          "version": "3.10.1",
+          "resolved": "https://registry.npmjs.org/@react-stately/utils/-/utils-3.10.1.tgz",
+          "integrity": "sha512-VS/EHRyicef25zDZcM/ClpzYMC5i2YGN6uegOeQawmgfGjb02yaCX0F0zR69Pod9m2Hr3wunTbtpgVXvYbZItg==",
+          "requires": {
+            "@swc/helpers": "^0.5.0"
+          }
+        }
       }
     },
     "@nextui-org/system-rsc": {
@@ -28003,16 +28628,16 @@
       }
     },
     "@react-aria/button": {
-      "version": "3.9.3",
-      "resolved": "https://registry.npmjs.org/@react-aria/button/-/button-3.9.3.tgz",
-      "integrity": "sha512-ZXo2VGTxfbaTEnfeIlm5ym4vYpGAy8sGrad8Scv+EyDAJWLMKokqctfaN6YSWbqUApC3FN63IvMqASflbmnYig==",
+      "version": "3.9.5",
+      "resolved": "https://registry.npmjs.org/@react-aria/button/-/button-3.9.5.tgz",
+      "integrity": "sha512-dgcYR6j8WDOMLKuVrtxzx4jIC05cVKDzc+HnPO8lNkBAOfjcuN5tkGRtIjLtqjMvpZHhQT5aDbgFpIaZzxgFIg==",
       "requires": {
-        "@react-aria/focus": "^3.16.2",
-        "@react-aria/interactions": "^3.21.1",
-        "@react-aria/utils": "^3.23.2",
-        "@react-stately/toggle": "^3.7.2",
-        "@react-types/button": "^3.9.2",
-        "@react-types/shared": "^3.22.1",
+        "@react-aria/focus": "^3.17.1",
+        "@react-aria/interactions": "^3.21.3",
+        "@react-aria/utils": "^3.24.1",
+        "@react-stately/toggle": "^3.7.4",
+        "@react-types/button": "^3.9.4",
+        "@react-types/shared": "^3.23.1",
         "@swc/helpers": "^0.5.0"
       }
     },
@@ -28069,13 +28694,13 @@
       }
     },
     "@react-aria/focus": {
-      "version": "3.16.2",
-      "resolved": "https://registry.npmjs.org/@react-aria/focus/-/focus-3.16.2.tgz",
-      "integrity": "sha512-Rqo9ummmgotESfypzFjI3uh58yMpL+E+lJBbQuXkBM0u0cU2YYzu0uOrFrq3zcHk997udZvq1pGK/R+2xk9B7g==",
+      "version": "3.17.1",
+      "resolved": "https://registry.npmjs.org/@react-aria/focus/-/focus-3.17.1.tgz",
+      "integrity": "sha512-FLTySoSNqX++u0nWZJPPN5etXY0WBxaIe/YuL/GTEeuqUIuC/2bJSaw5hlsM6T2yjy6Y/VAxBcKSdAFUlU6njQ==",
       "requires": {
-        "@react-aria/interactions": "^3.21.1",
-        "@react-aria/utils": "^3.23.2",
-        "@react-types/shared": "^3.22.1",
+        "@react-aria/interactions": "^3.21.3",
+        "@react-aria/utils": "^3.24.1",
+        "@react-types/shared": "^3.23.1",
         "@swc/helpers": "^0.5.0",
         "clsx": "^2.0.0"
       },
@@ -28121,28 +28746,28 @@
       }
     },
     "@react-aria/i18n": {
-      "version": "3.10.2",
-      "resolved": "https://registry.npmjs.org/@react-aria/i18n/-/i18n-3.10.2.tgz",
-      "integrity": "sha512-Z1ormoIvMOI4mEdcFLYsoJy9w/EzBdBmgfLP+S/Ah+1xwQOXpgwZxiKOhYHpWa0lf6hkKJL34N9MHJvCJ5Crvw==",
+      "version": "3.11.1",
+      "resolved": "https://registry.npmjs.org/@react-aria/i18n/-/i18n-3.11.1.tgz",
+      "integrity": "sha512-vuiBHw1kZruNMYeKkTGGnmPyMnM5T+gT8bz97H1FqIq1hQ6OPzmtBZ6W6l6OIMjeHI5oJo4utTwfZl495GALFQ==",
       "requires": {
-        "@internationalized/date": "^3.5.2",
-        "@internationalized/message": "^3.1.2",
-        "@internationalized/number": "^3.5.1",
-        "@internationalized/string": "^3.2.1",
-        "@react-aria/ssr": "^3.9.2",
-        "@react-aria/utils": "^3.23.2",
-        "@react-types/shared": "^3.22.1",
+        "@internationalized/date": "^3.5.4",
+        "@internationalized/message": "^3.1.4",
+        "@internationalized/number": "^3.5.3",
+        "@internationalized/string": "^3.2.3",
+        "@react-aria/ssr": "^3.9.4",
+        "@react-aria/utils": "^3.24.1",
+        "@react-types/shared": "^3.23.1",
         "@swc/helpers": "^0.5.0"
       }
     },
     "@react-aria/interactions": {
-      "version": "3.21.1",
-      "resolved": "https://registry.npmjs.org/@react-aria/interactions/-/interactions-3.21.1.tgz",
-      "integrity": "sha512-AlHf5SOzsShkHfV8GLLk3v9lEmYqYHURKcXWue0JdYbmquMRkUsf/+Tjl1+zHVAQ8lKqRnPYbTmc4AcZbqxltw==",
+      "version": "3.21.3",
+      "resolved": "https://registry.npmjs.org/@react-aria/interactions/-/interactions-3.21.3.tgz",
+      "integrity": "sha512-BWIuf4qCs5FreDJ9AguawLVS0lV9UU+sK4CCnbCNNmYqOWY+1+gRXCsnOM32K+oMESBxilAjdHW5n1hsMqYMpA==",
       "requires": {
-        "@react-aria/ssr": "^3.9.2",
-        "@react-aria/utils": "^3.23.2",
-        "@react-types/shared": "^3.22.1",
+        "@react-aria/ssr": "^3.9.4",
+        "@react-aria/utils": "^3.24.1",
+        "@react-types/shared": "^3.23.1",
         "@swc/helpers": "^0.5.0"
       }
     },
@@ -28214,20 +28839,20 @@
       }
     },
     "@react-aria/overlays": {
-      "version": "3.21.1",
-      "resolved": "https://registry.npmjs.org/@react-aria/overlays/-/overlays-3.21.1.tgz",
-      "integrity": "sha512-djEBDF+TbIIOHWWNpdm19+z8xtY8U+T+wKVQg/UZ6oWnclSqSWeGl70vu73Cg4HVBJ4hKf1SRx4Z/RN6VvH4Yw==",
+      "version": "3.22.1",
+      "resolved": "https://registry.npmjs.org/@react-aria/overlays/-/overlays-3.22.1.tgz",
+      "integrity": "sha512-GHiFMWO4EQ6+j6b5QCnNoOYiyx1Gk8ZiwLzzglCI4q1NY5AG2EAmfU4Z1+Gtrf2S5Y0zHbumC7rs9GnPoGLUYg==",
       "requires": {
-        "@react-aria/focus": "^3.16.2",
-        "@react-aria/i18n": "^3.10.2",
-        "@react-aria/interactions": "^3.21.1",
-        "@react-aria/ssr": "^3.9.2",
-        "@react-aria/utils": "^3.23.2",
-        "@react-aria/visually-hidden": "^3.8.10",
-        "@react-stately/overlays": "^3.6.5",
-        "@react-types/button": "^3.9.2",
-        "@react-types/overlays": "^3.8.5",
-        "@react-types/shared": "^3.22.1",
+        "@react-aria/focus": "^3.17.1",
+        "@react-aria/i18n": "^3.11.1",
+        "@react-aria/interactions": "^3.21.3",
+        "@react-aria/ssr": "^3.9.4",
+        "@react-aria/utils": "^3.24.1",
+        "@react-aria/visually-hidden": "^3.8.12",
+        "@react-stately/overlays": "^3.6.7",
+        "@react-types/button": "^3.9.4",
+        "@react-types/overlays": "^3.8.7",
+        "@react-types/shared": "^3.23.1",
         "@swc/helpers": "^0.5.0"
       }
     },
@@ -28292,9 +28917,9 @@
       }
     },
     "@react-aria/ssr": {
-      "version": "3.9.2",
-      "resolved": "https://registry.npmjs.org/@react-aria/ssr/-/ssr-3.9.2.tgz",
-      "integrity": "sha512-0gKkgDYdnq1w+ey8KzG9l+H5Z821qh9vVjztk55rUg71vTk/Eaebeir+WtzcLLwTjw3m/asIjx8Y59y1lJZhBw==",
+      "version": "3.9.5",
+      "resolved": "https://registry.npmjs.org/@react-aria/ssr/-/ssr-3.9.5.tgz",
+      "integrity": "sha512-xEwGKoysu+oXulibNUSkXf8itW0npHHTa6c4AyYeZIJyRoegeteYuFpZUBPtIDE8RfHdNsSmE1ssOkxRnwbkuQ==",
       "requires": {
         "@swc/helpers": "^0.5.0"
       }
@@ -28392,13 +29017,13 @@
       }
     },
     "@react-aria/utils": {
-      "version": "3.23.2",
-      "resolved": "https://registry.npmjs.org/@react-aria/utils/-/utils-3.23.2.tgz",
-      "integrity": "sha512-yznR9jJ0GG+YJvTMZxijQwVp+ahP66DY0apZf7X+dllyN+ByEDW+yaL1ewYPIpugxVzH5P8jhnBXsIyHKN411g==",
+      "version": "3.24.1",
+      "resolved": "https://registry.npmjs.org/@react-aria/utils/-/utils-3.24.1.tgz",
+      "integrity": "sha512-O3s9qhPMd6n42x9sKeJ3lhu5V1Tlnzhu6Yk8QOvDuXf7UGuUjXf9mzfHJt1dYzID4l9Fwm8toczBzPM9t0jc8Q==",
       "requires": {
-        "@react-aria/ssr": "^3.9.2",
-        "@react-stately/utils": "^3.9.1",
-        "@react-types/shared": "^3.22.1",
+        "@react-aria/ssr": "^3.9.4",
+        "@react-stately/utils": "^3.10.1",
+        "@react-types/shared": "^3.23.1",
         "@swc/helpers": "^0.5.0",
         "clsx": "^2.0.0"
       },
@@ -28411,14 +29036,50 @@
       }
     },
     "@react-aria/visually-hidden": {
-      "version": "3.8.10",
-      "resolved": "https://registry.npmjs.org/@react-aria/visually-hidden/-/visually-hidden-3.8.10.tgz",
-      "integrity": "sha512-np8c4wxdbE7ZrMv/bnjwEfpX0/nkWy9sELEb0sK8n4+HJ+WycoXXrVxBUb9tXgL/GCx5ReeDQChjQWwajm/z3A==",
+      "version": "3.8.14",
+      "resolved": "https://registry.npmjs.org/@react-aria/visually-hidden/-/visually-hidden-3.8.14.tgz",
+      "integrity": "sha512-DV3yagbAgO4ywQTq6D/AxcIaTC8c77r/SxlIMhQBMQ6vScJWTCh6zFG55wmLe3NKqvRrowv1OstlmYfZQ4v/XA==",
       "requires": {
-        "@react-aria/interactions": "^3.21.1",
-        "@react-aria/utils": "^3.23.2",
-        "@react-types/shared": "^3.22.1",
+        "@react-aria/interactions": "^3.22.1",
+        "@react-aria/utils": "^3.25.1",
+        "@react-types/shared": "^3.24.1",
         "@swc/helpers": "^0.5.0"
+      },
+      "dependencies": {
+        "@react-aria/interactions": {
+          "version": "3.22.1",
+          "resolved": "https://registry.npmjs.org/@react-aria/interactions/-/interactions-3.22.1.tgz",
+          "integrity": "sha512-5TLzQaDAQQ5C70yG8GInbO4wIylKY67RfTIIwQPGR/4n5OIjbUD8BOj3NuSsuZ/frUPaBXo1VEBBmSO23fxkjw==",
+          "requires": {
+            "@react-aria/ssr": "^3.9.5",
+            "@react-aria/utils": "^3.25.1",
+            "@react-types/shared": "^3.24.1",
+            "@swc/helpers": "^0.5.0"
+          }
+        },
+        "@react-aria/utils": {
+          "version": "3.25.1",
+          "resolved": "https://registry.npmjs.org/@react-aria/utils/-/utils-3.25.1.tgz",
+          "integrity": "sha512-5Uj864e7T5+yj78ZfLnfHqmypLiqW2mN+nsdslog2z5ssunTqjolVeM15ootXskjISlZ7MojLpq97kIC4nlnAw==",
+          "requires": {
+            "@react-aria/ssr": "^3.9.5",
+            "@react-stately/utils": "^3.10.2",
+            "@react-types/shared": "^3.24.1",
+            "@swc/helpers": "^0.5.0",
+            "clsx": "^2.0.0"
+          }
+        },
+        "@react-types/shared": {
+          "version": "3.24.1",
+          "resolved": "https://registry.npmjs.org/@react-types/shared/-/shared-3.24.1.tgz",
+          "integrity": "sha512-AUQeGYEm/zDTN6zLzdXolDxz3Jk5dDL7f506F07U8tBwxNNI3WRdhU84G0/AaFikOZzDXhOZDr3MhQMzyE7Ydw==",
+          "requires": {}
+        },
+        "clsx": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+          "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA=="
+        }
       }
     },
     "@react-spring/animated": {
@@ -28574,12 +29235,12 @@
       }
     },
     "@react-stately/overlays": {
-      "version": "3.6.5",
-      "resolved": "https://registry.npmjs.org/@react-stately/overlays/-/overlays-3.6.5.tgz",
-      "integrity": "sha512-U4rCFj6TPJPXLUvYXAcvh+yP/CO2W+7f0IuqP7ZZGE+Osk9qFkT+zRK5/6ayhBDFpmueNfjIEAzT9gYPQwNHFw==",
+      "version": "3.6.9",
+      "resolved": "https://registry.npmjs.org/@react-stately/overlays/-/overlays-3.6.9.tgz",
+      "integrity": "sha512-4chfyzKw7P2UEainm0yzjUgYwG1ovBejN88eTrn+O62x5huuMCwe0cbMxmYh4y7IhRFSee3jIJd0SP0u/+i39w==",
       "requires": {
-        "@react-stately/utils": "^3.9.1",
-        "@react-types/overlays": "^3.8.5",
+        "@react-stately/utils": "^3.10.2",
+        "@react-types/overlays": "^3.8.9",
         "@swc/helpers": "^0.5.0"
       }
     },
@@ -28658,12 +29319,12 @@
       }
     },
     "@react-stately/toggle": {
-      "version": "3.7.2",
-      "resolved": "https://registry.npmjs.org/@react-stately/toggle/-/toggle-3.7.2.tgz",
-      "integrity": "sha512-SHCF2btcoK57c4lyhucRbyPBAFpp0Pdp0vcPdn3hUgqbu6e5gE0CwG/mgFmZRAQoc7PRc7XifL0uNw8diJJI0Q==",
+      "version": "3.7.6",
+      "resolved": "https://registry.npmjs.org/@react-stately/toggle/-/toggle-3.7.6.tgz",
+      "integrity": "sha512-xRZyrjNVu1VCd1xpg5RwmNYs9fXb+JHChoUaRcBmGCCjsPD0R5uR3iNuE17RXJtWS3/8o9IJVn90+/7NW7boOg==",
       "requires": {
-        "@react-stately/utils": "^3.9.1",
-        "@react-types/checkbox": "^3.7.1",
+        "@react-stately/utils": "^3.10.2",
+        "@react-types/checkbox": "^3.8.3",
         "@swc/helpers": "^0.5.0"
       }
     },
@@ -28690,9 +29351,9 @@
       }
     },
     "@react-stately/utils": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/@react-stately/utils/-/utils-3.9.1.tgz",
-      "integrity": "sha512-yzw75GE0iUWiyps02BOAPTrybcsMIxEJlzXqtvllAb01O9uX5n0i3X+u2eCpj2UoDF4zS08Ps0jPgWxg8xEYtA==",
+      "version": "3.10.2",
+      "resolved": "https://registry.npmjs.org/@react-stately/utils/-/utils-3.10.2.tgz",
+      "integrity": "sha512-fh6OTQtbeQC0ywp6LJuuKs6tKIgFvt/DlIZEcIpGho6/oZG229UnIk6TUekwxnDbumuYyan6D9EgUtEMmT8UIg==",
       "requires": {
         "@swc/helpers": "^0.5.0"
       }
@@ -28725,19 +29386,27 @@
       }
     },
     "@react-types/button": {
-      "version": "3.9.2",
-      "resolved": "https://registry.npmjs.org/@react-types/button/-/button-3.9.2.tgz",
-      "integrity": "sha512-EnPTkGHZRtiwAoJy5q9lDjoG30bEzA/qnvKG29VVXKYAGeqY2IlFs1ypmU+z1X/CpJgPcG3I5cakM7yTVm3pSg==",
+      "version": "3.9.4",
+      "resolved": "https://registry.npmjs.org/@react-types/button/-/button-3.9.4.tgz",
+      "integrity": "sha512-raeQBJUxBp0axNF74TXB8/H50GY8Q3eV6cEKMbZFP1+Dzr09Ngv0tJBeW0ewAxAguNH5DRoMUAUGIXtSXskVdA==",
       "requires": {
-        "@react-types/shared": "^3.22.1"
+        "@react-types/shared": "^3.23.1"
       }
     },
     "@react-types/checkbox": {
-      "version": "3.7.1",
-      "resolved": "https://registry.npmjs.org/@react-types/checkbox/-/checkbox-3.7.1.tgz",
-      "integrity": "sha512-kuGqjQFex0As/3gfWyk+e9njCcad/ZdnYLLiNvhlk15730xfa0MmnOdpqo9jfuFSXBjOcpxoofvEhvrRMtEdUA==",
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/@react-types/checkbox/-/checkbox-3.8.3.tgz",
+      "integrity": "sha512-f4c1mnLEt0iS1NMkyZXgT3q3AgcxzDk7w6MSONOKydcnh0xG5L2oefY14DhVDLkAuQS7jThlUFwiAs+MxiO3MA==",
       "requires": {
-        "@react-types/shared": "^3.22.1"
+        "@react-types/shared": "^3.24.1"
+      },
+      "dependencies": {
+        "@react-types/shared": {
+          "version": "3.24.1",
+          "resolved": "https://registry.npmjs.org/@react-types/shared/-/shared-3.24.1.tgz",
+          "integrity": "sha512-AUQeGYEm/zDTN6zLzdXolDxz3Jk5dDL7f506F07U8tBwxNNI3WRdhU84G0/AaFikOZzDXhOZDr3MhQMzyE7Ydw==",
+          "requires": {}
+        }
       }
     },
     "@react-types/combobox": {
@@ -28791,11 +29460,19 @@
       }
     },
     "@react-types/overlays": {
-      "version": "3.8.5",
-      "resolved": "https://registry.npmjs.org/@react-types/overlays/-/overlays-3.8.5.tgz",
-      "integrity": "sha512-4D7EEBQigD/m8hE68Ys8eloyyZFHHduqykSIgINJ0edmo0jygRbWlTwuhWFR9USgSP4dK54duN0Mvq0m4HEVEw==",
+      "version": "3.8.9",
+      "resolved": "https://registry.npmjs.org/@react-types/overlays/-/overlays-3.8.9.tgz",
+      "integrity": "sha512-9ni9upQgXPnR+K9cWmbYWvm3ll9gH8P/XsEZprqIV5zNLMF334jADK48h4jafb1X9RFnj0WbHo6BqcSObzjTig==",
       "requires": {
-        "@react-types/shared": "^3.22.1"
+        "@react-types/shared": "^3.24.1"
+      },
+      "dependencies": {
+        "@react-types/shared": {
+          "version": "3.24.1",
+          "resolved": "https://registry.npmjs.org/@react-types/shared/-/shared-3.24.1.tgz",
+          "integrity": "sha512-AUQeGYEm/zDTN6zLzdXolDxz3Jk5dDL7f506F07U8tBwxNNI3WRdhU84G0/AaFikOZzDXhOZDr3MhQMzyE7Ydw==",
+          "requires": {}
+        }
       }
     },
     "@react-types/progress": {
@@ -33626,9 +34303,9 @@
       "integrity": "sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew=="
     },
     "framer-motion": {
-      "version": "10.16.16",
-      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-10.16.16.tgz",
-      "integrity": "sha512-je6j91rd7NmUX7L1XHouwJ4v3R+SO4umso2LUcgOct3rHZ0PajZ80ETYZTajzEXEl9DlKyzjyt4AvGQ+lrebOw==",
+      "version": "10.18.0",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-10.18.0.tgz",
+      "integrity": "sha512-oGlDh1Q1XqYPksuTD/usb0I70hq95OUzmL9+6Zd+Hs4XV0oaISBa/UUMSjYiq6m8EUF32132mOJ8xVZS+I0S6w==",
       "requires": {
         "@emotion/is-prop-valid": "^0.8.2",
         "tslib": "^2.4.0"
@@ -34176,13 +34853,13 @@
       }
     },
     "intl-messageformat": {
-      "version": "10.5.11",
-      "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-10.5.11.tgz",
-      "integrity": "sha512-eYq5fkFBVxc7GIFDzpFQkDOZgNayNTQn4Oufe8jw6YY6OHVw70/4pA3FyCsQ0Gb2DnvEJEMmN2tOaXUGByM+kg==",
+      "version": "10.5.14",
+      "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-10.5.14.tgz",
+      "integrity": "sha512-IjC6sI0X7YRjjyVH9aUgdftcmZK7WXdHeil4KwbjDnRWjnVitKpAx3rr6t6di1joFp5188VqKcobOPA6mCLG/w==",
       "requires": {
-        "@formatjs/ecma402-abstract": "1.18.2",
+        "@formatjs/ecma402-abstract": "2.0.0",
         "@formatjs/fast-memoize": "2.2.0",
-        "@formatjs/icu-messageformat-parser": "2.7.6",
+        "@formatjs/icu-messageformat-parser": "2.7.8",
         "tslib": "^2.4.0"
       }
     },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -3,9 +3,11 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "@nextui-org/button": "^2.0.37",
     "@nextui-org/popover": "^2.1.20",
     "@nextui-org/react": "^2.2.9",
     "@nextui-org/spinner": "^2.0.33",
+    "@nextui-org/system": "^2.2.5",
     "@nextui-org/tooltip": "^2.0.33",
     "@react-spring/parallax": "^9.7.3",
     "@testing-library/jest-dom": "^5.17.0",

--- a/frontend/src/components/HealthAdvice.js
+++ b/frontend/src/components/HealthAdvice.js
@@ -1,18 +1,16 @@
-import { useEffect, useState } from "react";
-import { Spinner } from "@nextui-org/spinner";
+import { useState } from "react";
+import { Button, Spinner } from "@nextui-org/react";
 
 import { getHealthAdviceData } from "../utils/get-data";
 
 export function HealthAdvice({ weatherData }) {
   const [healthAdviceData, setHealthAdviceData] = useState(null);
+  const [isLoading, setIsLoading] = useState(false);
 
-  useEffect(() => {
-    const getAndSetHealthAdviceData = async () => {
-      setHealthAdviceData(await getHealthAdviceData(weatherData));
-    };
-
-    getAndSetHealthAdviceData();
-  }, [weatherData]);
+  const getAndSetHealthAdviceData = async () => {
+    setHealthAdviceData(await getHealthAdviceData(weatherData));
+    setIsLoading(false);
+  };
 
   const extractAdviceHeading = (adviceString) => {
     const firstOccurrenceIndex = adviceString.indexOf("**");
@@ -39,7 +37,21 @@ export function HealthAdvice({ weatherData }) {
   return (
     <div className="flex flex-col gap-y-4 md:w-1/2 p-10">
       <h1 className="text-xl md:text-5xl font-bold">Our Advice:</h1>
-      {healthAdviceData ? (
+      {isLoading ? (
+        <Spinner />
+      ) : (
+        <Button
+          onPress={async () => {
+            setIsLoading(true);
+            setHealthAdviceData(null);
+            await getAndSetHealthAdviceData();
+          }}
+          color="primary"
+        >
+          Generate ✨
+        </Button>
+      )}
+      {healthAdviceData && (
         <ul className="flex flex-col gap-y-12 text-lg">
           {healthAdviceData.map((adviceString, i) => (
             <li key={i}>
@@ -48,8 +60,6 @@ export function HealthAdvice({ weatherData }) {
             </li>
           ))}
         </ul>
-      ) : (
-        <Spinner />
       )}
       <p>
         <strong className="text-danger">DISCLAIMER:</strong> This advice is


### PR DESCRIPTION
This PR introduces an improvement to the health advice generation feature. Initially I was making a request to the API on page load which requires the use of the useEffect hook which is not the best solution. Now the user can click a button to generate the health advice instead and because I have put a rate limit on my OpenAI account I won't get overcharged