### PR TITLE
fix: add the reverse geo router into the app

### DIFF
--- a/backend/api/reverse_geo_location/views.py
+++ b/backend/api/reverse_geo_location/views.py
@@ -3,9 +3,9 @@ from fastapi import APIRouter
 from api.reverse_geo_location.dtos import ReverseGeoLocationRes
 from api.reverse_geo_location.services import reverse_coordinates
 
-air_quality_router = APIRouter(prefix="/api/v1/air-quality")
+reverse_geo_loc_router = APIRouter(prefix="/api/v1/reverse-geo-location")
 
-@air_quality_router.get("/", response_model=ReverseGeoLocationRes)
+@reverse_geo_loc_router.get("/", response_model=ReverseGeoLocationRes)
 async def get_air_quality_for_location(lat: str, lon: str, limit: int) -> ReverseGeoLocationRes:
   reversed_coordinates = await reverse_coordinates(lat, lon, limit)
 

--- a/backend/app.py
+++ b/backend/app.py
@@ -8,6 +8,7 @@ from slowapi.middleware import SlowAPIMiddleware
 from api.health_advice.views import health_advice_router
 from api.weather.views import weather_router
 from api.air_quality.views import air_quality_router
+from api.reverse_geo_location.views import reverse_geo_loc_router
 
 
 limiter = Limiter(key_func=get_remote_address, default_limits=["100/minute"])
@@ -39,3 +40,4 @@ async def root():
 app.include_router(health_advice_router)
 app.include_router(weather_router)
 app.include_router(air_quality_router)
+app.include_router(reverse_geo_loc_router)


### PR DESCRIPTION
This PR introduces a fix because I forgot to add the Geo Location router into the FastAPI app instance